### PR TITLE
Fix build pipeline

### DIFF
--- a/build/Jenkinsfile
+++ b/build/Jenkinsfile
@@ -78,7 +78,7 @@ pipeline {
   }
   post {
     always {
-      discoverGitReferenceBuild defaultBranch: 'master'
+      discoverGitReferenceBuild()
     }
   }
 }


### PR DESCRIPTION
Remove deleted property 'defaultBranch' form discoverGitReferenceBuild step