### PR TITLE
XIVY-13377 Support deep data modification

### DIFF
--- a/packages/editor/src/components/blocks/layout/Layout.css
+++ b/packages/editor/src/components/blocks/layout/Layout.css
@@ -3,6 +3,7 @@
   flex-direction: row;
   gap: var(--size-1);
   flex-wrap: wrap;
+  border: var(--basic-border);
 }
 .block-flex .flex-column {
   flex: 1 1 calc(50% - var(--size-1));

--- a/packages/editor/src/components/blocks/layout/Layout.tsx
+++ b/packages/editor/src/components/blocks/layout/Layout.tsx
@@ -2,8 +2,9 @@ import { DropZone } from '../../editor/canvas/DropZone';
 import type { ComponentConfig, UiComponentProps } from '../../../types/config';
 import './Layout.css';
 import type { Layout, Prettify } from '@axonivy/form-editor-protocol';
-import { Draggable } from '../../editor/canvas/Draggable';
 import { config } from '../../components';
+import { ComponentBlock } from '../../editor/canvas/Canvas';
+import { LAYOUT_DROPZONE_ID_PREFIX } from '../../../data/data';
 
 type LayoutProps = Prettify<Layout>;
 
@@ -26,16 +27,16 @@ export const LayoutComponent: ComponentConfig<LayoutProps> = {
 const LayoutBlock = ({ id, components }: UiComponentProps<LayoutProps>) => {
   return (
     <div className='block-flex'>
-      {Array.from(Array(components).keys()).map(column => {
-        const component = components[column];
+      {[...components].map((component, index) => {
         return (
-          <div className='flex-column' key={column}>
-            <DropZone id={`${id}-column${column}`} visible={component === undefined}>
-              {component && <Draggable config={config.components[component.type]} data={component} />}
-            </DropZone>
+          <div className='flex-column' key={index}>
+            <ComponentBlock component={component} config={config} />
           </div>
         );
       })}
+      <div className='flex-column'>
+        <DropZone id={`${LAYOUT_DROPZONE_ID_PREFIX}${id}`} visible={true} />
+      </div>
     </div>
   );
 };

--- a/packages/editor/src/components/editor/canvas/Canvas.tsx
+++ b/packages/editor/src/components/editor/canvas/Canvas.tsx
@@ -3,7 +3,8 @@ import type { Config } from '../../../types/config';
 import { Draggable } from './Draggable';
 import { useAppContext } from '../../../context/useData';
 import { DropZone } from './DropZone';
-import { Fragment } from 'react';
+import type { Component, ComponentData } from '@axonivy/form-editor-protocol';
+import { CANVAS_DROPZONE_ID } from '../../../data/data';
 
 type CanvasProps = {
   config: Config;
@@ -14,13 +15,15 @@ export const Canvas = ({ config }: CanvasProps) => {
   return (
     <div className='canvas'>
       {data.components.map(obj => (
-        <Fragment key={obj.id}>
-          <DropZone id={obj.id}>
-            <Draggable config={config.components[obj.type]} data={obj} />
-          </DropZone>
-        </Fragment>
+        <ComponentBlock key={obj.id} component={obj} config={config} />
       ))}
-      <DropZone id='canvas' visible={true} />
+      <DropZone id={CANVAS_DROPZONE_ID} visible={true} />
     </div>
   );
 };
+
+export const ComponentBlock = ({ component, config }: { component: ComponentData | Component; config: Config }) => (
+  <DropZone id={component.id}>
+    <Draggable config={config.components[component.type]} data={component} />
+  </DropZone>
+);

--- a/packages/editor/src/components/editor/canvas/Draggable.tsx
+++ b/packages/editor/src/components/editor/canvas/Draggable.tsx
@@ -1,8 +1,9 @@
 import type { Component, ComponentData } from '@axonivy/form-editor-protocol';
-import { useAppContext } from '../../../context/useData';
+import { useAppContext, useData } from '../../../context/useData';
 import type { ComponentConfig } from '../../../types/config';
 import './Draggable.css';
 import { useDraggable } from '@dnd-kit/core';
+import { modifyData } from '../../../data/data';
 
 type DraggableProps = {
   config: ComponentConfig;
@@ -10,12 +11,28 @@ type DraggableProps = {
 };
 
 export const Draggable = ({ config, data }: DraggableProps) => {
+  const { setData } = useData();
   const { isDragging, attributes, listeners, setNodeRef } = useDraggable({ id: data.id });
   const appContext = useAppContext();
   const isSelected = appContext.selectedElement === data.id;
   return (
     <div
-      onClick={() => appContext.setSelectedElement(data.id)}
+      onClick={e => {
+        e.stopPropagation();
+        appContext.setSelectedElement(data.id);
+      }}
+      onKeyUp={e => {
+        e.stopPropagation();
+        if (e.key === 'Delete') {
+          setData(oldData => modifyData(oldData, { type: 'remove', data: { id: data.id } }));
+        }
+        if (e.key === 'ArrowUp') {
+          setData(oldData => modifyData(oldData, { type: 'moveUp', data: { id: data.id } }));
+        }
+        if (e.key === 'ArrowDown') {
+          setData(oldData => modifyData(oldData, { type: 'moveDown', data: { id: data.id } }));
+        }
+      }}
       className={`draggable${isSelected ? ' selected' : ''}${isDragging ? ' dragging' : ''}`}
       ref={setNodeRef}
       {...listeners}

--- a/packages/editor/src/components/editor/canvas/DropZone.tsx
+++ b/packages/editor/src/components/editor/canvas/DropZone.tsx
@@ -10,7 +10,7 @@ type DropZoneProps = {
 
 export const DropZone = ({ id, visible, children }: DropZoneProps) => {
   const dnd = useDndContext();
-  const { isOver, setNodeRef } = useDroppable({ id: `DropZone-${id}`, disabled: dnd.active?.id === id });
+  const { isOver, setNodeRef } = useDroppable({ id, disabled: dnd.active?.id === id });
   return (
     <div ref={setNodeRef} className={`drop-zone${isOver ? ' is-drop-target' : ''}`}>
       <div className={`drop-zone-block${visible ? ' visible' : ''}`} />

--- a/packages/editor/src/components/editor/properties/PropertyItem.tsx
+++ b/packages/editor/src/components/editor/properties/PropertyItem.tsx
@@ -29,7 +29,7 @@ export const PropertyItem = ({ fieldName, field }: PropertyItemProps) => {
     }
   };
   useEffect(() => {
-    setValue(element ? element.config[fieldName] : '');
+    setValue(element ? (element.config[fieldName] as PrimitiveValue) : '');
   }, [element, fieldName]);
   const inputFor = (field: Field, label: string) => {
     switch (field.type) {

--- a/packages/editor/src/context/DndContext.tsx
+++ b/packages/editor/src/context/DndContext.tsx
@@ -17,9 +17,9 @@ export const DndContext = ({ children }: { children: ReactNode }) => {
   const { setData } = useData();
   const [activeId, setActiveId] = useState<string | undefined>();
   const handleDragEnd = (event: DragEndEvent) => {
-    const target = event.over?.id;
-    if (target && activeId) {
-      setData(oldData => modifyData(oldData, activeId, target));
+    const targetId = event.over?.id;
+    if (targetId && activeId) {
+      setData(oldData => modifyData(oldData, { type: 'dnd', data: { activeId, targetId } }));
     }
     setActiveId(undefined);
   };

--- a/packages/editor/src/data/data.test.ts
+++ b/packages/editor/src/data/data.test.ts
@@ -1,56 +1,160 @@
-import { EMPTY_FORM, type FormData } from '@axonivy/form-editor-protocol';
+import { EMPTY_FORM, type ComponentData, type FormData, isLayout } from '@axonivy/form-editor-protocol';
 import { modifyData } from './data';
 import type { DeepPartial } from '../test-utils/type-utils';
 
-describe('data', () => {
-  const emptyData: FormData = EMPTY_FORM;
+describe('modifyData', () => {
+  describe('drag and drop', () => {
+    test('add unknown', () => {
+      expect(modifyData(emptyData(), { type: 'dnd', data: { activeId: 'unknown', targetId: '' } })).to.deep.equals(emptyData());
+    });
 
-  test('modifyData - add unknown', () => {
-    expect(modifyData(emptyData, 'unknown', '')).to.deep.equals(emptyData);
+    test('add one', () => {
+      const data = modifyData(emptyData(), { type: 'dnd', data: { activeId: 'Input', targetId: '' } });
+      expect(data).to.not.deep.equals(emptyData);
+      expect(data.components).to.have.length(1);
+      expect(data.components[0].id).to.match(/^Input-/);
+      expect(data.components[0].type).to.equals('Input');
+      expect(data.components[0].config).to.not.undefined;
+    });
+
+    test('add two', () => {
+      let data = modifyData(emptyData(), { type: 'dnd', data: { activeId: 'Input', targetId: '' } });
+      data = modifyData(data, { type: 'dnd', data: { activeId: 'Button', targetId: '' } });
+      expect(data).to.not.deep.equals(emptyData());
+      expect(data.components).to.have.length(2);
+      expect(data.components[1].type).to.equals('Button');
+    });
+
+    test('add deep', () => {
+      let data = modifyData(emptyData(), { type: 'dnd', data: { activeId: 'Layout', targetId: '' } });
+      data = modifyData(data, { type: 'dnd', data: { activeId: 'Button', targetId: `layout-${data.components[0].id}` } });
+      data = modifyData(data, { type: 'dnd', data: { activeId: 'Text', targetId: `layout-${data.components[0].id}` } });
+      expect(data).to.not.deep.equals(emptyData());
+      expect(data.components).to.have.length(1);
+      const layoutData = data.components[0].config.components as ComponentData[];
+      expect(layoutData).to.have.length(2);
+      expect(layoutData[0].type).to.equals('Button');
+      expect(layoutData[1].type).to.equals('Text');
+    });
+
+    test('move down', () => {
+      const data = filledData();
+      expectOrder(modifyData(data, { type: 'dnd', data: { activeId: '1', targetId: '2' } }), ['1', '2', '3']);
+      expectOrder(modifyData(data, { type: 'dnd', data: { activeId: '1', targetId: '3' } }), ['2', '1', '3']);
+      expectOrder(modifyData(data, { type: 'dnd', data: { activeId: '1', targetId: '4' } }), ['2', '3', '1']);
+    });
+
+    test('move down deep', () => {
+      const data = modifyData(filledData(), { type: 'dnd', data: { activeId: '31', targetId: '33' } });
+      expectOrder(data, ['1', '2', '3']);
+      expectOrderDeep(data, '3', ['32', '31', '33']);
+    });
+
+    test('move up', () => {
+      const data = filledData();
+      expectOrder(modifyData(data, { type: 'dnd', data: { activeId: '3', targetId: '3' } }), ['1', '2', '3']);
+      expectOrder(modifyData(data, { type: 'dnd', data: { activeId: '3', targetId: '2' } }), ['1', '3', '2']);
+      expectOrder(modifyData(data, { type: 'dnd', data: { activeId: '3', targetId: '1' } }), ['3', '1', '2']);
+    });
+
+    test('move up deep', () => {
+      const data = modifyData(filledData(), { type: 'dnd', data: { activeId: '33', targetId: '32' } });
+      expectOrder(data, ['1', '2', '3']);
+      expectOrderDeep(data, '3', ['31', '33', '32']);
+    });
+
+    test('move down to deep', () => {
+      const data = modifyData(filledData(), { type: 'dnd', data: { activeId: '1', targetId: '32' } });
+      expectOrder(data, ['2', '3']);
+      expectOrderDeep(data, '3', ['31', '1', '32', '33']);
+    });
+
+    test('move up from deep', () => {
+      const data = modifyData(filledData(), { type: 'dnd', data: { activeId: '32', targetId: '2' } });
+      expectOrder(data, ['1', '32', '2', '3']);
+      expectOrderDeep(data, '3', ['31', '33']);
+    });
   });
 
-  test('modifyData - add one', () => {
-    const addedInput = modifyData(emptyData, 'Input', '');
-    expect(addedInput).to.not.deep.equals(emptyData);
-    expect(addedInput.components).to.have.length(1);
-    expect(addedInput.components[0].id).to.match(/^Input-/);
-    expect(addedInput.components[0].type).to.equals('Input');
-    expect(addedInput.components[0].config).to.not.undefined;
+  describe('remove', () => {
+    test('remove', () => {
+      const data = filledData();
+      expectOrder(modifyData(data, { type: 'remove', data: { id: '1' } }), ['2', '3']);
+      expectOrder(modifyData(data, { type: 'remove', data: { id: '2' } }), ['1', '3']);
+      expectOrder(modifyData(data, { type: 'remove', data: { id: '3' } }), ['1', '2']);
+    });
+
+    test('remove deep', () => {
+      const removeDeep = modifyData(filledData(), { type: 'remove', data: { id: '32' } });
+      expectOrder(removeDeep, ['1', '2', '3']);
+      expectOrderDeep(removeDeep, '3', ['31', '33']);
+    });
   });
 
-  test('modifyData - add two', () => {
-    const addedInput = modifyData(emptyData, 'Input', '');
-    const addedButton = modifyData(addedInput, 'Button', '');
-    expect(addedButton).to.not.deep.equals(addedInput);
-    expect(addedButton.components).to.have.length(2);
-    expect(addedButton.components[1].type).to.equals('Button');
+  describe('move', () => {
+    test('down', () => {
+      const data = filledData();
+      expectOrder(modifyData(data, { type: 'moveDown', data: { id: '2' } }), ['1', '3', '2']);
+    });
+
+    test('down deep', () => {
+      const data = filledData();
+      expectOrderDeep(modifyData(data, { type: 'moveDown', data: { id: '31' } }), '3', ['32', '31', '33']);
+    });
+
+    test('up', () => {
+      const data = filledData();
+      expectOrder(modifyData(data, { type: 'moveUp', data: { id: '2' } }), ['2', '1', '3']);
+    });
+
+    test('up deep', () => {
+      const data = filledData();
+      expectOrderDeep(modifyData(data, { type: 'moveUp', data: { id: '33' } }), '3', ['31', '33', '32']);
+    });
+
+    test('first and last', () => {
+      const data = filledData();
+      expectOrder(modifyData(data, { type: 'moveUp', data: { id: '1' } }), ['1', '2', '3']);
+      expectOrder(modifyData(data, { type: 'moveDown', data: { id: '3' } }), ['1', '2', '3']);
+    });
   });
 
-  const prefilledData: DeepPartial<FormData> = {
-    components: [
-      { id: '1', type: 'Input', config: {} },
-      { id: '2', type: 'Button', config: {} },
-      { id: '3', type: 'Text', config: {} }
-    ]
+  const emptyData = () => {
+    return structuredClone(EMPTY_FORM);
   };
 
-  test('modifyData - move down', () => {
-    const data = prefilledData as FormData;
-    expectOrder(data, ['1', '2', '3']);
-    expectOrder(modifyData(data, '1', '2'), ['1', '2', '3']);
-    expectOrder(modifyData(data, '1', '3'), ['2', '1', '3']);
-    expectOrder(modifyData(data, '1', '4'), ['2', '3', '1']);
-  });
-
-  test('modifyData - move up', () => {
-    const data = prefilledData as FormData;
-    expectOrder(data, ['1', '2', '3']);
-    expectOrder(modifyData(data, '3', '3'), ['1', '2', '3']);
-    expectOrder(modifyData(data, '3', '2'), ['1', '3', '2']);
-    expectOrder(modifyData(data, '3', '1'), ['3', '1', '2']);
-  });
+  const filledData = () => {
+    const prefilledData: DeepPartial<FormData> = {
+      components: [
+        { id: '1', type: 'Input', config: {} },
+        { id: '2', type: 'Button', config: {} },
+        {
+          id: '3',
+          type: 'Layout',
+          config: {
+            components: [
+              { id: '31', type: 'Text', config: {} },
+              { id: '32', type: 'Button', config: {} },
+              { id: '33', type: 'Input', config: {} }
+            ]
+          }
+        }
+      ]
+    };
+    const filledData = prefilledData as FormData;
+    expectOrder(filledData, ['1', '2', '3']);
+    expectOrderDeep(filledData, '3', ['31', '32', '33']);
+    return filledData;
+  };
 
   const expectOrder = (data: FormData, order: string[]) => {
     expect(data.components.map(c => c.id)).to.eql(order);
+  };
+
+  const expectOrderDeep = (data: FormData, deepId: string, order: string[]) => {
+    const component = data.components.find(c => c.id === deepId);
+    if (component && isLayout(component)) {
+      expect(component.config.components.map(c => c.id)).to.eql(order);
+    }
   };
 });

--- a/packages/editor/src/data/data.ts
+++ b/packages/editor/src/data/data.ts
@@ -1,41 +1,127 @@
 import type { UniqueIdentifier } from '@dnd-kit/core';
 import type { ComponentConfig } from '../types/config';
 import { componentByName } from '../components/components';
-import { move } from '../utils/array';
+import { add, remove } from '../utils/array';
 import { v4 as uuid } from 'uuid';
-import type { ComponentData, FormData } from '@axonivy/form-editor-protocol';
+import { isLayout, type ComponentData, type FormData } from '@axonivy/form-editor-protocol';
 
-const targetIndex = (data: ComponentData[], target: UniqueIdentifier) => {
-  const id = `${target}`.replace('DropZone-', '');
-  const targetIndex = data.findIndex(obj => obj.id === id);
-  if (targetIndex === -1) {
-    return data.length;
+export const CANVAS_DROPZONE_ID = 'canvas';
+export const LAYOUT_DROPZONE_ID_PREFIX = 'layout-';
+
+const findComponent = (data: Array<ComponentData>, id: string): { data: Array<ComponentData>; index: number } | undefined => {
+  if (id === CANVAS_DROPZONE_ID) {
+    return { data, index: data.length };
   }
-  return targetIndex;
-};
-
-const addNewComponent = (component: ComponentConfig, data: ComponentData[], target: UniqueIdentifier) => {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  data.push({ id: `${component.name}-${uuid()}`, type: component.name, config: structuredClone<any>(component.defaultProps) });
-  move(data, data.length - 1, targetIndex(data, target));
-};
-
-const moveComponent = (id: string, data: ComponentData[], target: UniqueIdentifier) => {
-  const element = data.find(obj => obj.id === id);
-  if (element) {
-    const fromIndex = data.indexOf(element);
-    const toIndex = targetIndex(data, target);
-    move(data, fromIndex, fromIndex < toIndex ? toIndex - 1 : toIndex);
+  if (id.startsWith(LAYOUT_DROPZONE_ID_PREFIX)) {
+    return findLayoutComponent(data, id.replace(LAYOUT_DROPZONE_ID_PREFIX, ''));
   }
+  return findComponentDeep(data, id);
 };
 
-export const modifyData = (data: FormData, activeId: string, targetId: UniqueIdentifier) => {
-  const newData = structuredClone(data);
-  const component = componentByName(activeId);
+const findComponentDeep = (data: Array<ComponentData>, id: string) => {
+  const index = data.findIndex(obj => obj.id === id);
+  if (index < 0) {
+    for (const element of data) {
+      if (isLayout(element)) {
+        const find = findComponent(element.config.components, id);
+        if (find) {
+          return find;
+        }
+      }
+    }
+    return;
+  }
+  return { data, index };
+};
+
+const findLayoutComponent = (data: Array<ComponentData>, id: string) => {
+  const find = findComponentDeep(data, id);
+  if (find) {
+    const layout = find.data[find.index];
+    if (isLayout(layout)) {
+      const layoutData = layout.config.components;
+      return { data: layoutData, index: layoutData.length };
+    }
+  }
+  return;
+};
+
+const addNewComponent = (data: Array<ComponentData>, component: ComponentConfig, target: string) => {
+  const newComponent: ComponentData = {
+    id: `${component.name}-${uuid()}`,
+    type: component.name,
+    config: structuredClone(component.defaultProps) as Extract<ComponentData, 'config'>
+  };
+  addComponent(data, newComponent, target);
+};
+
+const addComponent = (data: Array<ComponentData>, component: ComponentData, id: string) => {
+  const find = findComponent(data, id);
+  if (find) {
+    add(find.data, component, find.index);
+    return;
+  }
+  data.push(component);
+};
+
+const removeComponent = (data: Array<ComponentData>, id: string) => {
+  const find = findComponent(data, id);
+  if (find) {
+    return remove(find.data, find.index);
+  }
+  return;
+};
+
+const moveComponent = (data: Array<ComponentData>, id: string, indexMove: number) => {
+  const find = findComponent(data, id);
+  if (find) {
+    const removed = remove(find.data, find.index);
+    const moveIndex = find.index + indexMove < 0 ? 0 : find.index + indexMove;
+    add(find.data, removed, moveIndex);
+  }
+  return;
+};
+
+type ModifyAction =
+  | {
+      type: 'dnd';
+      data: {
+        activeId: string;
+        targetId: UniqueIdentifier;
+      };
+    }
+  | {
+      type: 'remove' | 'moveUp' | 'moveDown';
+      data: { id: string };
+    };
+
+const dndModify = (data: Array<ComponentData>, action: Extract<ModifyAction, { type: 'dnd' }>['data']) => {
+  const component = componentByName(action.activeId);
   if (component) {
-    addNewComponent(component, newData.components, targetId);
+    addNewComponent(data, component, action.targetId as string);
   } else {
-    moveComponent(activeId, newData.components, targetId);
+    const removed = removeComponent(data, action.activeId);
+    if (removed) {
+      addComponent(data, removed, action.targetId as string);
+    }
+  }
+};
+
+export const modifyData = (data: FormData, action: ModifyAction) => {
+  const newData = structuredClone(data);
+  switch (action.type) {
+    case 'dnd':
+      dndModify(newData.components, action.data);
+      break;
+    case 'remove':
+      removeComponent(newData.components, action.data.id);
+      break;
+    case 'moveUp':
+      moveComponent(newData.components, action.data.id, -1);
+      break;
+    case 'moveDown':
+      moveComponent(newData.components, action.data.id, 1);
+      break;
   }
   return newData;
 };

--- a/packages/editor/src/utils/array.test.ts
+++ b/packages/editor/src/utils/array.test.ts
@@ -1,4 +1,4 @@
-import { groupBy, move } from './array';
+import { add, groupBy, move, remove } from './array';
 
 const car1 = { type: 'suv', vendor: 'bmw' } as const;
 const car2 = { type: 'suv', vendor: 'volvo', price: 1000 } as const;
@@ -16,5 +16,28 @@ describe('array util', () => {
     expect(array).toEqual(array);
     move(array, 0, 1);
     expect(array).toEqual([{ a: 2 }, { a: 1 }]);
+  });
+
+  test('remove', () => {
+    const arr1 = [{ a: 1 }, { a: 2 }];
+    const element1 = remove(arr1, 0);
+    expect(arr1).toEqual([{ a: 2 }]);
+    expect(element1).toEqual({ a: 1 });
+
+    const arr2 = [{ a: 1 }, { a: 2 }];
+    const element2 = remove(arr2, 1);
+    expect(arr2).toEqual([{ a: 1 }]);
+    expect(element2).toEqual({ a: 2 });
+  });
+
+  test('add', () => {
+    const array = [{ a: 1 }, { a: 2 }];
+    expect(array).toEqual(array);
+
+    add(array, { a: 3 }, 0);
+    expect(array).toEqual([{ a: 3 }, { a: 1 }, { a: 2 }]);
+
+    add(array, { a: 4 }, 2);
+    expect(array).toEqual([{ a: 3 }, { a: 1 }, { a: 4 }, { a: 2 }]);
   });
 });

--- a/packages/editor/src/utils/array.ts
+++ b/packages/editor/src/utils/array.ts
@@ -1,5 +1,5 @@
-export const groupBy = <T>(arr: T[], fn: (item: T) => string) => {
-  return arr.reduce<Record<string, T[]>>((prev, curr) => {
+export const groupBy = <T>(arr: Array<T>, fn: (item: T) => string) => {
+  return arr.reduce<Record<string, Array<T>>>((prev, curr) => {
     const groupKey = fn(curr);
     const group = prev[groupKey] || [];
     group.push(curr);
@@ -7,8 +7,15 @@ export const groupBy = <T>(arr: T[], fn: (item: T) => string) => {
   }, {});
 };
 
-export const move = <TArr extends object>(arr: TArr[], fromIndex: number, toIndex: number) => {
-  const element = arr[fromIndex];
-  arr.splice(fromIndex, 1);
-  arr.splice(toIndex, 0, element);
+export const move = <T extends object>(arr: Array<T>, fromIndex: number, toIndex: number) => {
+  const element = remove(arr, fromIndex);
+  add(arr, element, toIndex);
+};
+
+export const remove = <T extends object>(arr: Array<T>, index: number) => {
+  return arr.splice(index, 1)[0];
+};
+
+export const add = <T extends object>(arr: Array<T>, element: T, index: number) => {
+  arr.splice(index, 0, element);
 };

--- a/packages/protocol/src/data/form-data.ts
+++ b/packages/protocol/src/data/form-data.ts
@@ -8,9 +8,15 @@ export type ComponentConfigKeys = KeysOfUnion<Component['config']>;
 export type PrimitiveValue = string | boolean | number;
 
 export type ComponentData = Omit<Component, 'config'> & {
-  config: Record<string, PrimitiveValue>;
+  config: Record<string, PrimitiveValue | Array<ComponentData>>;
 };
 
+type LayoutConfig = ComponentData & { config: { components: Array<ComponentData> } };
+
 export type FormData = Omit<Form, 'components' | '$schema'> & {
-  components: ComponentData[];
+  components: Array<ComponentData>;
+};
+
+export const isLayout = (component: ComponentData): component is LayoutConfig => {
+  return component.type === 'Layout' && 'components' in component.config;
 };


### PR DESCRIPTION
- Drag new or existing block into or out of a layout block (move element into other elements children section).
- Add some keyboard actions:
  - Delete: delete selected element
  - ArrowUp: move selected element upwards
  - ArrowDown: move selected element downwards

Currently the dnd behaviour inside layouts is not ideal. So I will try to improve this in a followup PR.
![Screen Recording 2024-02-29 at 11 54 05](https://github.com/axonivy/form-editor-client/assets/42733123/451e4d3f-38ba-405d-ba22-96d652852dcb)