### PR TITLE
XIVY-13377 Improve layout dnd behavior

### DIFF
--- a/integrations/standalone/src/mock/form-client-mock.ts
+++ b/integrations/standalone/src/mock/form-client-mock.ts
@@ -18,6 +18,16 @@ export class FormClientMock implements FormClient {
           name: 'Proceed',
           variant: 'PRIMARY'
         }
+      },
+      {
+        id: '3',
+        type: 'Layout',
+        config: {
+          components: [
+            { id: '31', type: 'Text', config: { content: 'bla' } },
+            { id: '32', type: 'Button', config: { name: 'hi', variant: 'SECONDARY' } }
+          ]
+        }
       }
     ]
   };

--- a/packages/editor/src/components/blocks/layout/Layout.css
+++ b/packages/editor/src/components/blocks/layout/Layout.css
@@ -1,24 +1,13 @@
 .block-flex {
   display: flex;
   flex-direction: row;
-  gap: var(--size-1);
+  gap: var(--size-4);
   flex-wrap: wrap;
-  border: var(--basic-border);
 }
-.block-flex .flex-column {
-  flex: 1 1 calc(50% - var(--size-1));
+.block-flex > div {
+  flex: 1 1 calc(50% - var(--size-4));
+  border: 2px solid transparent;
 }
-.block-flex .flex-column:empty:before {
-  margin: 5px;
-  background-color: #ddd;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  min-height: 30px;
-  opacity: 0.3;
-  border-radius: var(--border-radius);
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  content: 'Column';
+.selected > .block-flex > div {
+  border: 2px dashed var(--P75);
 }

--- a/packages/editor/src/components/blocks/layout/Layout.tsx
+++ b/packages/editor/src/components/blocks/layout/Layout.tsx
@@ -1,9 +1,8 @@
-import { DropZone } from '../../editor/canvas/DropZone';
 import type { ComponentConfig, UiComponentProps } from '../../../types/config';
 import './Layout.css';
 import type { Layout, Prettify } from '@axonivy/form-editor-protocol';
 import { config } from '../../components';
-import { ComponentBlock } from '../../editor/canvas/Canvas';
+import { ComponentBlock, EmtpyBlock } from '../../editor/canvas/Canvas';
 import { LAYOUT_DROPZONE_ID_PREFIX } from '../../../data/data';
 
 type LayoutProps = Prettify<Layout>;
@@ -27,16 +26,10 @@ export const LayoutComponent: ComponentConfig<LayoutProps> = {
 const LayoutBlock = ({ id, components }: UiComponentProps<LayoutProps>) => {
   return (
     <div className='block-flex'>
-      {[...components].map((component, index) => {
-        return (
-          <div className='flex-column' key={index}>
-            <ComponentBlock component={component} config={config} />
-          </div>
-        );
+      {components.map((component, index) => {
+        return <ComponentBlock key={component.id} component={component} config={config} preId={components[index - 1]?.id} />;
       })}
-      <div className='flex-column'>
-        <DropZone id={`${LAYOUT_DROPZONE_ID_PREFIX}${id}`} visible={true} />
-      </div>
+      <EmtpyBlock id={`${LAYOUT_DROPZONE_ID_PREFIX}${id}`} preId={components[components.length - 1]?.id} />
     </div>
   );
 };

--- a/packages/editor/src/components/editor/ItemDragOverlay.tsx
+++ b/packages/editor/src/components/editor/ItemDragOverlay.tsx
@@ -1,4 +1,5 @@
 import { useData } from '../../context/useData';
+import { findComponent } from '../../data/data';
 import { componentByName } from '../components';
 import { DraggableOverlay } from './canvas/Draggable';
 import { PaletteItemOverlay } from './palette/PaletteItem';
@@ -12,8 +13,9 @@ export const ItemDragOverlay = ({ activeId }: { activeId?: string }) => {
   if (component) {
     return <PaletteItemOverlay item={component} />;
   }
-  const element = data.components.find(obj => obj.id === activeId);
-  if (element) {
+  const find = findComponent(data.components, activeId);
+  if (find) {
+    const element = find.data[find.index];
     const component = componentByName(element.type);
     return <DraggableOverlay config={component} data={element} />;
   }

--- a/packages/editor/src/components/editor/canvas/Canvas.css
+++ b/packages/editor/src/components/editor/canvas/Canvas.css
@@ -3,6 +3,20 @@
   box-shadow: 0 0 0 1rem var(--N75);
   display: flex;
   flex-direction: column;
-  gap: 1px;
-  margin: 1rem;
+  margin: var(--size-4);
+  overflow: auto;
+}
+
+.empty-block:before {
+  margin: var(--size-1);
+  background-color: var(--N300);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 30px;
+  opacity: 0.3;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  content: 'Empty';
 }

--- a/packages/editor/src/components/editor/canvas/Canvas.tsx
+++ b/packages/editor/src/components/editor/canvas/Canvas.tsx
@@ -14,16 +14,22 @@ export const Canvas = ({ config }: CanvasProps) => {
   const { data } = useAppContext();
   return (
     <div className='canvas'>
-      {data.components.map(obj => (
-        <ComponentBlock key={obj.id} component={obj} config={config} />
+      {data.components.map((component, index) => (
+        <ComponentBlock key={component.id} component={component} config={config} preId={data.components[index - 1]?.id} />
       ))}
-      <DropZone id={CANVAS_DROPZONE_ID} visible={true} />
+      <EmtpyBlock id={CANVAS_DROPZONE_ID} preId={data.components[data.components.length - 1]?.id} />
     </div>
   );
 };
 
-export const ComponentBlock = ({ component, config }: { component: ComponentData | Component; config: Config }) => (
-  <DropZone id={component.id}>
+export const ComponentBlock = ({ component, config, preId }: { component: ComponentData | Component; config: Config; preId?: string }) => (
+  <DropZone id={component.id} preId={preId}>
     <Draggable config={config.components[component.type]} data={component} />
+  </DropZone>
+);
+
+export const EmtpyBlock = ({ id, preId }: { id: string; preId: string }) => (
+  <DropZone id={id} preId={preId}>
+    <div className='empty-block' />
   </DropZone>
 );

--- a/packages/editor/src/components/editor/canvas/Draggable.css
+++ b/packages/editor/src/components/editor/canvas/Draggable.css
@@ -1,14 +1,15 @@
 .draggable {
-  padding: var(--size-1);
+  padding: var(--size-2) var(--size-4);
+  border: 1px solid transparent;
 }
-.draggable:hover {
+.draggable:hover:not(:has(.draggable:hover)) {
   background-color: var(--P50);
 }
-.draggable:where(.selected, .dragging) {
-  outline: var(--activ-border);
-  background-color: var(--background);
-  z-index: 2;
+.draggable.selected,
+.draggable.dragging {
+  border: var(--activ-border);
+  background-color: transparent;
 }
 .draggable.dragging {
-  opacity: 0.5;
+  opacity: 0.7;
 }

--- a/packages/editor/src/components/editor/canvas/Draggable.tsx
+++ b/packages/editor/src/components/editor/canvas/Draggable.tsx
@@ -4,6 +4,7 @@ import type { ComponentConfig } from '../../../types/config';
 import './Draggable.css';
 import { useDraggable } from '@dnd-kit/core';
 import { modifyData } from '../../../data/data';
+import { dragData } from './drag-data';
 
 type DraggableProps = {
   config: ComponentConfig;
@@ -12,7 +13,7 @@ type DraggableProps = {
 
 export const Draggable = ({ config, data }: DraggableProps) => {
   const { setData } = useData();
-  const { isDragging, attributes, listeners, setNodeRef } = useDraggable({ id: data.id });
+  const { isDragging, attributes, listeners, setNodeRef } = useDraggable({ id: data.id, data: dragData(data) });
   const appContext = useAppContext();
   const isSelected = appContext.selectedElement === data.id;
   return (

--- a/packages/editor/src/components/editor/canvas/DropZone.css
+++ b/packages/editor/src/components/editor/canvas/DropZone.css
@@ -2,13 +2,8 @@
   height: 0;
   transition: height 0.1s ease-out;
 }
-.drop-zone .drop-zone-block.visible {
+.drop-zone.is-drop-target > .drop-zone-block {
   background: var(--P75);
-  height: 20px;
-  margin-block-start: 2px;
-}
-.drop-zone.is-drop-target .drop-zone-block {
-  background: var(--P75);
-  height: 30px;
+  height: var(--size-4);
   outline: 2px dashed var(--P300);
 }

--- a/packages/editor/src/components/editor/canvas/DropZone.tsx
+++ b/packages/editor/src/components/editor/canvas/DropZone.tsx
@@ -1,19 +1,20 @@
 import { useDndContext, useDroppable } from '@dnd-kit/core';
 import './DropZone.css';
 import type { ReactNode } from 'react';
+import { isDropZoneDisabled } from './drag-data';
 
 type DropZoneProps = {
   id: string;
-  visible?: boolean;
+  preId?: string;
   children?: ReactNode;
 };
 
-export const DropZone = ({ id, visible, children }: DropZoneProps) => {
+export const DropZone = ({ id, preId, children }: DropZoneProps) => {
   const dnd = useDndContext();
-  const { isOver, setNodeRef } = useDroppable({ id, disabled: dnd.active?.id === id });
+  const { isOver, setNodeRef } = useDroppable({ id, disabled: isDropZoneDisabled(id, dnd.active, preId) });
   return (
     <div ref={setNodeRef} className={`drop-zone${isOver ? ' is-drop-target' : ''}`}>
-      <div className={`drop-zone-block${visible ? ' visible' : ''}`} />
+      <div className='drop-zone-block' />
       {children}
     </div>
   );

--- a/packages/editor/src/components/editor/canvas/drag-data.test.ts
+++ b/packages/editor/src/components/editor/canvas/drag-data.test.ts
@@ -1,0 +1,55 @@
+import type { FormData } from '@axonivy/form-editor-protocol';
+import { dragData, isDropZoneDisabled, type DragData } from './drag-data';
+import type { DeepPartial } from '../../../test-utils/type-utils';
+import type { Active } from '@dnd-kit/core';
+
+describe('dragData', () => {
+  test('normal', () => {
+    const data = filledData();
+    expectDragData(dragData(data.components[0]), []);
+  });
+
+  test('layout', () => {
+    const data = filledData();
+    expectDragData(dragData(data.components[2]), ['31', '32', '33']);
+  });
+});
+
+describe('isDragZoneDisabled', () => {
+  test('false', () => {
+    const active: Partial<Active> = { id: '1', data: { current: undefined } };
+    expect(isDropZoneDisabled('', active as Active)).to.be.false;
+    expect(isDropZoneDisabled('2', active as Active)).to.be.false;
+  });
+
+  test('true', () => {
+    const active: Partial<Active> = { id: '1', data: { current: undefined } };
+    expect(isDropZoneDisabled('1', active as Active)).to.be.true;
+    expect(isDropZoneDisabled('2', active as Active, '1')).to.be.true;
+  });
+});
+
+const expectDragData = (data: DragData, ids: Array<string>) => {
+  expect(data).to.deep.equals({ disabledIds: ids });
+};
+
+const filledData = () => {
+  const prefilledData: DeepPartial<FormData> = {
+    components: [
+      { id: '1', type: 'Input', config: {} },
+      { id: '2', type: 'Button', config: {} },
+      {
+        id: '3',
+        type: 'Layout',
+        config: {
+          components: [
+            { id: '31', type: 'Text', config: {} },
+            { id: '32', type: 'Button', config: {} },
+            { id: '33', type: 'Input', config: {} }
+          ]
+        }
+      }
+    ]
+  };
+  return prefilledData as FormData;
+};

--- a/packages/editor/src/components/editor/canvas/drag-data.ts
+++ b/packages/editor/src/components/editor/canvas/drag-data.ts
@@ -1,0 +1,37 @@
+import { isLayout, type Component, type ComponentData } from '@axonivy/form-editor-protocol';
+import type { Active } from '@dnd-kit/core';
+import { LAYOUT_DROPZONE_ID_PREFIX } from '../../../data/data';
+
+export type DragData = { disabledIds: Array<string> };
+
+const disabledIds = (data: Component | ComponentData): Array<string> => {
+  if (isLayout(data)) {
+    const ids: Array<string> = [];
+    for (const component of data.config.components) {
+      ids.push(...disabledIds(component));
+      ids.push(component.id);
+    }
+    return ids;
+  }
+  return [];
+};
+
+export const dragData = (data: Component | ComponentData): DragData => {
+  return { disabledIds: disabledIds(data) };
+};
+
+const isDragData = (data: unknown): data is DragData => {
+  return typeof data === 'object' && data !== null && 'disabledIds' in data;
+};
+
+export const isDropZoneDisabled = (id: string, active: Active | null, preId?: string) => {
+  const dropZoneId = active?.id;
+  if (dropZoneId === id || `${LAYOUT_DROPZONE_ID_PREFIX}${dropZoneId}` === id || dropZoneId === preId) {
+    return true;
+  }
+  const data = active?.data.current;
+  if (isDragData(data)) {
+    return data.disabledIds.includes(id);
+  }
+  return false;
+};

--- a/packages/editor/src/components/editor/palette/Palette.tsx
+++ b/packages/editor/src/components/editor/palette/Palette.tsx
@@ -12,7 +12,7 @@ export const Palette = ({ items }: PaletteProps) => {
   return (
     <Flex direction='column' className='palette'>
       <SidebarHeader icon={IvyIcons.LaneSwimlanes} title='Components' />
-      <Accordion type='multiple' defaultValue={[Object.keys(items)[0]]}>
+      <Accordion type='single' defaultValue={Object.keys(items)[0]}>
         {Object.entries(items).map(([category, groupItems]) => (
           <AccordionItem key={category} value={category}>
             <AccordionTrigger>{category}</AccordionTrigger>

--- a/packages/editor/src/data/data.test.ts
+++ b/packages/editor/src/data/data.test.ts
@@ -1,6 +1,20 @@
 import { EMPTY_FORM, type ComponentData, type FormData, isLayout } from '@axonivy/form-editor-protocol';
-import { modifyData } from './data';
+import { findComponent, modifyData } from './data';
 import type { DeepPartial } from '../test-utils/type-utils';
+
+describe('findComponent', () => {
+  test('find', () => {
+    const data = filledData();
+    expect(findComponent(data.components, '3')).to.deep.equals({ data: data.components, index: 2 });
+    expect(findComponent(data.components, '5')).to.deep.equals(undefined);
+  });
+
+  test('find deep', () => {
+    const data = filledData();
+    expect(findComponent(data.components, '31')).to.deep.equals({ data: data.components[2].config.components, index: 0 });
+    expect(findComponent(data.components, '35')).to.deep.equals(undefined);
+  });
+});
 
 describe('modifyData', () => {
   describe('drag and drop', () => {
@@ -118,43 +132,43 @@ describe('modifyData', () => {
       expectOrder(modifyData(data, { type: 'moveDown', data: { id: '3' } }), ['1', '2', '3']);
     });
   });
-
-  const emptyData = () => {
-    return structuredClone(EMPTY_FORM);
-  };
-
-  const filledData = () => {
-    const prefilledData: DeepPartial<FormData> = {
-      components: [
-        { id: '1', type: 'Input', config: {} },
-        { id: '2', type: 'Button', config: {} },
-        {
-          id: '3',
-          type: 'Layout',
-          config: {
-            components: [
-              { id: '31', type: 'Text', config: {} },
-              { id: '32', type: 'Button', config: {} },
-              { id: '33', type: 'Input', config: {} }
-            ]
-          }
-        }
-      ]
-    };
-    const filledData = prefilledData as FormData;
-    expectOrder(filledData, ['1', '2', '3']);
-    expectOrderDeep(filledData, '3', ['31', '32', '33']);
-    return filledData;
-  };
-
-  const expectOrder = (data: FormData, order: string[]) => {
-    expect(data.components.map(c => c.id)).to.eql(order);
-  };
-
-  const expectOrderDeep = (data: FormData, deepId: string, order: string[]) => {
-    const component = data.components.find(c => c.id === deepId);
-    if (component && isLayout(component)) {
-      expect(component.config.components.map(c => c.id)).to.eql(order);
-    }
-  };
 });
+
+const emptyData = () => {
+  return structuredClone(EMPTY_FORM);
+};
+
+const filledData = () => {
+  const prefilledData: DeepPartial<FormData> = {
+    components: [
+      { id: '1', type: 'Input', config: {} },
+      { id: '2', type: 'Button', config: {} },
+      {
+        id: '3',
+        type: 'Layout',
+        config: {
+          components: [
+            { id: '31', type: 'Text', config: {} },
+            { id: '32', type: 'Button', config: {} },
+            { id: '33', type: 'Input', config: {} }
+          ]
+        }
+      }
+    ]
+  };
+  const filledData = prefilledData as FormData;
+  expectOrder(filledData, ['1', '2', '3']);
+  expectOrderDeep(filledData, '3', ['31', '32', '33']);
+  return filledData;
+};
+
+const expectOrder = (data: FormData, order: string[]) => {
+  expect(data.components.map(c => c.id)).to.eql(order);
+};
+
+const expectOrderDeep = (data: FormData, deepId: string, order: string[]) => {
+  const component = data.components.find(c => c.id === deepId);
+  if (component && isLayout(component)) {
+    expect(component.config.components.map(c => c.id)).to.eql(order);
+  }
+};

--- a/packages/editor/src/data/data.ts
+++ b/packages/editor/src/data/data.ts
@@ -8,7 +8,7 @@ import { isLayout, type ComponentData, type FormData } from '@axonivy/form-edito
 export const CANVAS_DROPZONE_ID = 'canvas';
 export const LAYOUT_DROPZONE_ID_PREFIX = 'layout-';
 
-const findComponent = (data: Array<ComponentData>, id: string): { data: Array<ComponentData>; index: number } | undefined => {
+export const findComponent = (data: Array<ComponentData>, id: string): { data: Array<ComponentData>; index: number } | undefined => {
   if (id === CANVAS_DROPZONE_ID) {
     return { data, index: data.length };
   }

--- a/packages/protocol/src/data/form-data.ts
+++ b/packages/protocol/src/data/form-data.ts
@@ -17,6 +17,6 @@ export type FormData = Omit<Form, 'components' | '$schema'> & {
   components: Array<ComponentData>;
 };
 
-export const isLayout = (component: ComponentData): component is LayoutConfig => {
+export const isLayout = (component: Component | ComponentData): component is LayoutConfig => {
   return component.type === 'Layout' && 'components' in component.config;
 };


### PR DESCRIPTION
- Improve the dnd behavior
  - disable all included dropzones for a layout component (it makes no sense to drop a layout into itself :D)
  - disable dropzone for the previous element (as this change has no effect to the order)
- Update the design a bit
  - enable scroll for big forms

![Screen Recording 2024-03-01 at 10 33 39](https://github.com/axonivy/form-editor-client/assets/42733123/49327440-c64c-4a4f-a84e-6180269cc2b5)
