### PR TITLE
XIVY-13261 Add Subsections to the Properties

### DIFF
--- a/packages/editor/src/components/blocks/base.ts
+++ b/packages/editor/src/components/blocks/base.ts
@@ -17,6 +17,6 @@ const spanOptions: FieldOption<string>[] = [
 ] as const;
 
 export const baseComponentFields: Fields<BaseComponentProps> = {
-  lgSpan: { type: 'select', label: 'Large Span', options: spanOptions, section: 'Layout' },
-  mdSpan: { type: 'select', label: 'Medium Span', options: spanOptions, section: 'Layout' }
+  lgSpan: { section: 'Layout', subsection: 'General', type: 'select', label: 'Large Span', options: spanOptions },
+  mdSpan: { section: 'Layout', subsection: 'General', type: 'select', label: 'Medium Span', options: spanOptions }
 };

--- a/packages/editor/src/components/blocks/button/Button.tsx
+++ b/packages/editor/src/components/blocks/button/Button.tsx
@@ -34,10 +34,10 @@ export const ButtonComponent: ComponentConfig<ButtonProps> = {
   defaultProps: defaultButtonProps,
   render: props => <ButtonBlock {...props} />,
   fields: {
-    name: { label: 'Name', type: 'text' },
-    action: { label: 'Action', type: 'text' },
-    variant: { label: 'Variant', type: 'select', options: variantOptions },
-    icon: { label: 'Icon', type: 'select', options: iconOptions },
+    name: { subsection: 'General', label: 'Name', type: 'text' },
+    action: { subsection: 'General', label: 'Action', type: 'text' },
+    variant: { subsection: 'General', label: 'Variant', type: 'select', options: variantOptions },
+    icon: { subsection: 'General', label: 'Icon', type: 'select', options: iconOptions },
     ...baseComponentFields
   }
 };

--- a/packages/editor/src/components/blocks/input/Input.tsx
+++ b/packages/editor/src/components/blocks/input/Input.tsx
@@ -28,10 +28,10 @@ export const InputComponent: ComponentConfig<InputProps> = {
   defaultProps: defaultInputProps,
   render: props => <UiInput {...props} />,
   fields: {
-    label: { type: 'text' },
-    required: { type: 'checkbox' },
-    value: { type: 'text' },
-    type: { type: 'select', options: typeOptions },
+    label: { subsection: 'General', type: 'text' },
+    required: { subsection: 'General', type: 'checkbox' },
+    value: { subsection: 'General', type: 'text' },
+    type: { subsection: 'General', type: 'select', options: typeOptions },
     ...baseComponentFields
   }
 };

--- a/packages/editor/src/components/blocks/layout/Layout.tsx
+++ b/packages/editor/src/components/blocks/layout/Layout.tsx
@@ -42,15 +42,17 @@ export const LayoutComponent: ComponentConfig<LayoutProps> = {
   defaultProps: defaultLayoutProps,
   render: props => <LayoutBlock {...props} />,
   fields: {
-    components: { type: 'hidden' },
-    type: { type: 'select', options: typeOptions },
+    components: { subsection: 'General', type: 'hidden' },
+    type: { subsection: 'General', type: 'select', options: typeOptions },
     justifyContent: {
+      subsection: 'General',
       type: 'select',
       label: 'Justify content',
       options: justifyContentOptions,
       hide: data => data.type !== 'FLEX'
     },
     gridVariant: {
+      subsection: 'General',
       type: 'select',
       label: 'Columns',
       options: gridVariantOptions,

--- a/packages/editor/src/components/blocks/link/Link.tsx
+++ b/packages/editor/src/components/blocks/link/Link.tsx
@@ -20,8 +20,8 @@ export const LinkComponent: ComponentConfig<LinkProps> = {
   defaultProps: defaultLinkProps,
   render: props => <LinkBlock {...props} />,
   fields: {
-    name: { type: 'text' },
-    href: { type: 'text' },
+    name: { subsection: 'General', type: 'text' },
+    href: { subsection: 'General', type: 'text' },
     ...baseComponentFields
   }
 };

--- a/packages/editor/src/components/blocks/text/Text.tsx
+++ b/packages/editor/src/components/blocks/text/Text.tsx
@@ -25,8 +25,8 @@ export const TextComponent: ComponentConfig<TextProps> = {
   defaultProps: defaultTextProps,
   render: props => <TextBlock {...props} />,
   fields: {
-    content: { type: 'textarea' },
-    type: { type: 'select', options: typeOptions },
+    content: { subsection: 'General', type: 'textarea' },
+    type: { subsection: 'General', type: 'select', options: typeOptions },
     ...baseComponentFields
   }
 };

--- a/packages/editor/src/types/config.ts
+++ b/packages/editor/src/types/config.ts
@@ -13,7 +13,10 @@ export type FieldOption<TValue = PrimitiveValue> = {
   value: TValue;
 };
 
+type Subsection = 'General' | 'Styling' | 'Behaviour';
+
 export type BaseField<ComponentProps extends DefaultComponentProps = DefaultComponentProps> = {
+  subsection: Subsection;
   label?: string;
   hide?: (component: ComponentProps) => boolean;
   section?: 'Layout';


### PR DESCRIPTION
I have built the subsections into the form editor. Currently they are all in the General section. What kind of subsections there should be is better dealt with in a separate story.
What do you think of this solution?
![subsections](https://github.com/axonivy/form-editor-client/assets/141223521/821a7bad-1ead-41f3-9baa-a20a17f6b1cb)

At the moment all collapsibles are always open, I have not yet implemented the same behaviour as with the inscription view (if everything is configured, the collapsible is closed or the status circle at the collapsible trigger). Should I try to implement that in this story as well? I think the whole undo and data handling is not quite as advanced as with the Inscription View and could therefore be a bit more work.
