### PR TITLE
XIVY-13261 Add no element selected property

### DIFF
--- a/packages/editor/src/components/editor/properties/EmptyDetail.css
+++ b/packages/editor/src/components/editor/properties/EmptyDetail.css
@@ -1,0 +1,15 @@
+.empty-detail {
+  display: flex;
+  height: 100%;
+  color: var(--N800);
+}
+
+.empty-detail .empty-detail-icon {
+  font-size: 54px;
+}
+
+.empty-detail .empty-detail-message {
+  font-size: 14px;
+  text-align: center;
+  width: 70%;
+}

--- a/packages/editor/src/components/editor/properties/EmptyDetail.tsx
+++ b/packages/editor/src/components/editor/properties/EmptyDetail.tsx
@@ -1,0 +1,16 @@
+import { Flex, IvyIcon, Message } from '@axonivy/ui-components';
+import { IvyIcons } from '@axonivy/ui-icons';
+import './EmptyDetail.css';
+
+type EmptyDetailProps = {
+  message: string;
+};
+
+export const EmptyDetail = ({ message }: EmptyDetailProps) => {
+  return (
+    <Flex justifyContent='center' alignItems='center' direction='column' className='empty-detail'>
+      <IvyIcon icon={IvyIcons.DragDrop} className='empty-detail-icon' />
+      <Message className='empty-detail-message'>{message}</Message>
+    </Flex>
+  );
+};

--- a/packages/editor/src/components/editor/properties/Properties.tsx
+++ b/packages/editor/src/components/editor/properties/Properties.tsx
@@ -15,6 +15,7 @@ import {
 import { IvyIcons } from '@axonivy/ui-icons';
 import { isFreeLayout, type ConfigData, type PrimitiveValue, type ComponentData } from '@axonivy/form-editor-protocol';
 import { groupBy } from '../../../utils/array';
+import { EmptyDetail } from './EmptyDetail';
 
 type PropertiesProps = {
   config: Config;
@@ -54,7 +55,7 @@ const visibleSections = (fields: ReturnType<typeof visibleFields>, parent?: Comp
 export const Properties = ({ config }: PropertiesProps) => {
   const { element, setElement, parent } = useData();
   if (element === undefined) {
-    return null;
+    return <EmptyDetail message='Nothing there yet. Select an Element to edit its properties.' />;
   }
   const propertyConfig = config.components[element.type];
   if (propertyConfig === undefined || propertyConfig.fields === undefined) {


### PR DESCRIPTION
I have added a default property if no element is selected, analogue to the variable editor.
![grafik](https://github.com/axonivy/form-editor-client/assets/141223521/9bd964d6-b060-4998-b5e0-0bcead1ff340)
