### PR TITLE
XIVY-13261 Improve Overlay

### DIFF
--- a/packages/editor/src/components/editor/canvas/Draggable.tsx
+++ b/packages/editor/src/components/editor/canvas/Draggable.tsx
@@ -6,6 +6,7 @@ import { useDraggable } from '@dnd-kit/core';
 import { modifyData } from '../../../data/data';
 import { dragData } from './drag-data';
 import { useReadonly } from '@axonivy/ui-components';
+import useDraggableOverWidth from '../../../utils/useDraggableOverWidth';
 
 type DraggableProps = {
   config: ComponentConfig;
@@ -49,5 +50,10 @@ export const Draggable = ({ config, data }: DraggableProps) => {
 
 export const DraggableOverlay = ({ config, data }: DraggableProps) => {
   const elementConfig = { ...config.defaultProps, ...data.config };
-  return <div className='draggable dragging'>{config.render({ ...elementConfig, id: data.id })}</div>;
+  const width = useDraggableOverWidth();
+  return (
+    <div className='draggable dragging' style={{ width }}>
+      {config.render({ ...elementConfig, id: data.id })}
+    </div>
+  );
 };

--- a/packages/editor/src/components/editor/palette/PaletteItem.tsx
+++ b/packages/editor/src/components/editor/palette/PaletteItem.tsx
@@ -1,6 +1,8 @@
 import { useDraggable } from '@dnd-kit/core';
 import type { PaletteConfig } from './palette-config';
 import './PaletteItem.css';
+import { config } from '../../components';
+import useDraggableOverWidth from '../../../utils/useDraggableOverWidth';
 
 type PaletteItemProps = {
   item: PaletteConfig;
@@ -19,14 +21,13 @@ export const PaletteItem = ({ item }: PaletteItemProps) => {
 };
 
 export const PaletteItemOverlay = ({ item }: Partial<PaletteItemProps>) => {
+  const width = useDraggableOverWidth();
+
   return (
     <>
       {item && (
-        <div className='palette-item'>
-          <svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'>
-            <path fill='currentColor' d={item.icon}></path>
-          </svg>
-          <span>{item.name}</span>
+        <div className='draggable dragging' style={{ width }}>
+          {config.components[item.name].render(config.components[item.name].defaultProps)}
         </div>
       )}
     </>

--- a/packages/editor/src/utils/useDraggableOverWidth.ts
+++ b/packages/editor/src/utils/useDraggableOverWidth.ts
@@ -1,0 +1,17 @@
+import { useDndContext } from '@dnd-kit/core';
+import { useState, useEffect } from 'react';
+
+const useDraggableOverWidth = (initialWidth = 200) => {
+  const { over } = useDndContext();
+  const [width, setWidth] = useState(initialWidth);
+
+  useEffect(() => {
+    if (over && over?.rect.width !== width) {
+      setWidth(over?.rect.width);
+    }
+  }, [over, width]);
+
+  return width;
+};
+
+export default useDraggableOverWidth;


### PR DESCRIPTION
If you now drag a component from the toolbar into the canvas, a preview of the actual component is displayed directly. In addition, the overlay width now adapts to the effective width that it will need later.
![overlay](https://github.com/axonivy/form-editor-client/assets/141223521/2edd0074-9557-417c-8ab7-6423dd4b3c5f)
