### PR TITLE
XIVY-13261 Improve Collision detection algorithm

### DIFF
--- a/packages/editor/src/components/blocks/layout/Layout.tsx
+++ b/packages/editor/src/components/blocks/layout/Layout.tsx
@@ -88,7 +88,7 @@ const LayoutBlock = ({ id, components, type, justifyContent, gridVariant }: UiCo
           );
         })}
       </div>
-      <EmtpyBlock id={`${LAYOUT_DROPZONE_ID_PREFIX}${id}`} preId={components[components.length - 1]?.id} />
+      <EmtpyBlock id={`${LAYOUT_DROPZONE_ID_PREFIX}${id}`} preId={components[components.length - 1]?.id} forLayout={true} />
     </>
   );
 };

--- a/packages/editor/src/components/editor/canvas/Canvas.css
+++ b/packages/editor/src/components/editor/canvas/Canvas.css
@@ -33,16 +33,10 @@
   display: none;
 }
 
-.empty-block:before {
-  margin: var(--size-2);
-  padding: var(--size-3);
-  background-color: var(--N300);
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  opacity: 0.3;
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  content: 'DropZone';
+.empty-block {
+  height: 1px;
+}
+
+.empty-block.for-layout {
+  height: var(--size-4);
 }

--- a/packages/editor/src/components/editor/canvas/Canvas.tsx
+++ b/packages/editor/src/components/editor/canvas/Canvas.tsx
@@ -34,8 +34,8 @@ export const ComponentBlock = ({ component, config, preId, ...props }: Component
   </DropZone>
 );
 
-export const EmtpyBlock = ({ id, preId }: { id: string; preId: string }) => (
+export const EmtpyBlock = ({ id, preId, forLayout }: { id: string; preId: string; forLayout?: boolean }) => (
   <DropZone id={id} preId={preId}>
-    <div className='empty-block' />
+    <div className={`empty-block${forLayout ? ' for-layout' : ''}`} />
   </DropZone>
 );


### PR DESCRIPTION
I have managed to "remove" the DropZone, or rather I have made it so small that the user cannot see it. To ensure that the dnd still works, I had to adjust the collision detection algorithm slightly. For most cases, the pointerWithin is still used, but a mix between rectIntercept and pointerWithin is used to detect the canvas drop zone. 

This approach has the advantage that I can leave everything else (add-mechanisms/dropzones etc.) as it is. It works quiet good this way (see GIF). What do you think?

![collisionDetectionOwn](https://github.com/axonivy/form-editor-client/assets/141223521/26202c7a-0edf-4bb5-8ae1-effffd785ed1)
