### PR TITLE
Improve layout and empty state

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -96,18 +96,18 @@
       "link": true
     },
     "node_modules/@axonivy/jsonrpc": {
-      "version": "11.4.0-next.233",
-      "resolved": "https://npmjs-registry.ivyteam.ch/@axonivy/jsonrpc/-/jsonrpc-11.4.0-next.233.tgz",
-      "integrity": "sha512-72inVi1Utx9Cz8UJO4EK8chQAw92ltxe4qSimu61XjTw2/XdHmIONdSOy2+eZWqAjPhf77t/0iIZ/7gBUXk8Ww==",
+      "version": "11.4.0-next.243",
+      "resolved": "https://npmjs-registry.ivyteam.ch/@axonivy/jsonrpc/-/jsonrpc-11.4.0-next.243.tgz",
+      "integrity": "sha512-yf6Sp5c/sRqgFW3MrTaKRMSj8c1QSATAyrRRUNtELbFkFQrtIQcQHMlvu32EjbfxhwDtoiMDGz0HwTbkQicEYg==",
       "dependencies": {
         "vscode-jsonrpc": "^8.2.0",
         "vscode-ws-jsonrpc": "^3.0.0"
       }
     },
     "node_modules/@axonivy/ui-components": {
-      "version": "11.4.0-next.233",
-      "resolved": "https://npmjs-registry.ivyteam.ch/@axonivy/ui-components/-/ui-components-11.4.0-next.233.tgz",
-      "integrity": "sha512-K//5H2b3tjBXNm75+uFWsGtBVjzTlIUt0kqzm9CG7osIRdJZd67OLgauzje/eqbju3QMENnNCFEIyfAaypnxLg==",
+      "version": "11.4.0-next.243",
+      "resolved": "https://npmjs-registry.ivyteam.ch/@axonivy/ui-components/-/ui-components-11.4.0-next.243.tgz",
+      "integrity": "sha512-zAFaYrTEtpCys9B7rMA6McONPXBW58uB3n+dPnqQ0PHTpP+fcHtIVkefxYCMWatTj4m8YRg3VUETRlQoNGC4iA==",
       "dependencies": {
         "@radix-ui/react-accordion": "1.1.2",
         "@radix-ui/react-checkbox": "1.0.4",
@@ -136,9 +136,9 @@
       }
     },
     "node_modules/@axonivy/ui-icons": {
-      "version": "11.4.0-next.233",
-      "resolved": "https://npmjs-registry.ivyteam.ch/@axonivy/ui-icons/-/ui-icons-11.4.0-next.233.tgz",
-      "integrity": "sha512-tKqcQKu1MJRrIs7ls5TEKFdzlOPo4tSmkK2Aax3wj0IS5GdukQfhEZpzj5GKwrFcLPIKTooWZbeQqfGoJRI7zw=="
+      "version": "11.4.0-next.243",
+      "resolved": "https://npmjs-registry.ivyteam.ch/@axonivy/ui-icons/-/ui-icons-11.4.0-next.243.tgz",
+      "integrity": "sha512-bu+aNDw0cAxXmukRa3HsOFUkDDj8u7ULTXocfH6sWcOtCHNbgaGNEpA0N99y6Spr+2pM1oFxWJT61iCQuYZlYA=="
     },
     "node_modules/@babel/code-frame": {
       "version": "7.24.7",
@@ -17513,7 +17513,7 @@
       "license": "(EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0)",
       "dependencies": {
         "@axonivy/form-editor-protocol": "~11.4.0-next",
-        "@axonivy/jsonrpc": "~11.4.0-next.233"
+        "@axonivy/jsonrpc": "~11.4.0-next.243"
       },
       "devDependencies": {
         "vite": "^5.2.8"
@@ -17525,8 +17525,8 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@axonivy/form-editor-protocol": "~11.4.0-next",
-        "@axonivy/ui-components": "~11.4.0-next.233",
-        "@axonivy/ui-icons": "~11.4.0-next.233",
+        "@axonivy/ui-components": "~11.4.0-next.243",
+        "@axonivy/ui-icons": "~11.4.0-next.243",
         "@dnd-kit/core": "^6.1.0",
         "@tanstack/react-query": "5.32.1",
         "@tanstack/react-query-devtools": "5.32.1",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -15,7 +15,7 @@
   ],
   "dependencies": {
     "@axonivy/form-editor-protocol": "~11.4.0-next",
-    "@axonivy/jsonrpc": "~11.4.0-next.233"
+    "@axonivy/jsonrpc": "~11.4.0-next.243"
   },
   "devDependencies": {
     "vite": "^5.2.8"

--- a/packages/editor/package.json
+++ b/packages/editor/package.json
@@ -15,8 +15,8 @@
   ],
   "dependencies": {
     "@axonivy/form-editor-protocol": "~11.4.0-next",
-    "@axonivy/ui-components": "~11.4.0-next.233",
-    "@axonivy/ui-icons": "~11.4.0-next.233",
+    "@axonivy/ui-components": "~11.4.0-next.243",
+    "@axonivy/ui-icons": "~11.4.0-next.243",
     "@dnd-kit/core": "^6.1.0",
     "@tanstack/react-query": "5.32.1",
     "@tanstack/react-query-devtools": "5.32.1",

--- a/packages/editor/src/components/blocks/layout/Layout.css
+++ b/packages/editor/src/components/blocks/layout/Layout.css
@@ -71,9 +71,13 @@
 }
 
 .block-layout > div {
-  border: var(--layout-border-size, 2px) solid transparent;
+  border: var(--layout-border-size, 1px) dashed var(--N100);
 }
+
+.block-layout > div > div {
+  border: none;
+}
+
 .selected > .block-layout > div {
   border: var(--layout-border-size, 2px) dashed var(--P75);
-  border-radius: var(--border-r2);
 }

--- a/packages/editor/src/components/blocks/layout/Layout.tsx
+++ b/packages/editor/src/components/blocks/layout/Layout.tsx
@@ -64,6 +64,7 @@ export const LayoutComponent: ComponentConfig<LayoutProps> = {
 
 const LayoutBlock = ({ id, components, type, justifyContent, gridVariant }: UiComponentProps<LayoutProps>) => {
   const { ui } = useAppContext();
+
   return (
     <>
       <div
@@ -88,7 +89,12 @@ const LayoutBlock = ({ id, components, type, justifyContent, gridVariant }: UiCo
           );
         })}
       </div>
-      <EmtpyBlock id={`${LAYOUT_DROPZONE_ID_PREFIX}${id}`} preId={components[components.length - 1]?.id} forLayout={true} />
+      <EmtpyBlock
+        id={`${LAYOUT_DROPZONE_ID_PREFIX}${id}`}
+        preId={components[components.length - 1]?.id}
+        forLayout={true}
+        dragHint={{ display: components.length === 0, message: 'Drag first element inside the layout', mode: 'row' }}
+      />
     </>
   );
 };

--- a/packages/editor/src/components/editor/Editor.tsx
+++ b/packages/editor/src/components/editor/Editor.tsx
@@ -1,7 +1,7 @@
 import { Canvas } from './canvas/Canvas';
 import { Properties } from './properties/Properties';
 import './Editor.css';
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { AppProvider, useUiState } from '../../context/useData';
 import { config } from '../components';
 import { Flex, ResizableHandle, ResizablePanel, ResizablePanelGroup } from '@axonivy/ui-components';
@@ -41,6 +41,8 @@ export const Editor = (props: FormEditorProps) => {
     structuralSharing: false
   });
 
+  const toolbarDiv = useRef<HTMLDivElement>(null);
+
   const mutation = useMutation({
     mutationKey: queryKeys.saveData(),
     mutationFn: (updateData: Unary<FormData>) => {
@@ -76,13 +78,13 @@ export const Editor = (props: FormEditorProps) => {
             minSize={30}
             className='panel'
             onClick={e => {
-              if (e.target !== e.currentTarget) {
+              if (e.target !== e.currentTarget && !toolbarDiv.current?.contains(e.target as Node)) {
                 setSelectedElement(undefined);
               }
             }}
           >
             <Flex direction='column' className='canvas-panel'>
-              <FormToolbar />
+              <FormToolbar ref={toolbarDiv} />
               <ErrorBoundary FallbackComponent={ErrorFallback} resetKeys={[ui.dataStructure]}>
                 {ui.dataStructure ? <DataStructure /> : <Canvas config={config} />}
               </ErrorBoundary>

--- a/packages/editor/src/components/editor/FormToolbar.tsx
+++ b/packages/editor/src/components/editor/FormToolbar.tsx
@@ -21,13 +21,18 @@ import {
 import { IvyIcons } from '@axonivy/ui-icons';
 import { useAppContext } from '../../context/useData';
 import { PaletteCategoryPopover } from './palette/PaletteCategoryPopup';
+import { forwardRef, useEffect } from 'react';
 
 type ResponsiveMode = 'desktop' | 'tablet' | 'mobile';
 
-export const FormToolbar = () => {
-  const { ui, setUi } = useAppContext();
+export const FormToolbar = forwardRef<HTMLDivElement>((_, ref) => {
+  const { ui, setUi, selectedElement } = useAppContext();
   const { theme, setTheme } = useTheme();
   const editable = !useReadonly();
+
+  useEffect(() => {
+    setUi(old => ({ ...old, properties: selectedElement === undefined ? false : true }));
+  }, [selectedElement, setUi]);
 
   const changeResponsiveMode = (value: ResponsiveMode) => {
     if (value) {
@@ -38,7 +43,7 @@ export const FormToolbar = () => {
   };
 
   return (
-    <Toolbar>
+    <Toolbar ref={ref}>
       <Flex>
         <ToggleGroup type='single' onValueChange={changeResponsiveMode} defaultValue='desktop' gap={1} aria-label='Class selection'>
           <ToggleGroupItem value='mobile' asChild>
@@ -130,4 +135,4 @@ export const FormToolbar = () => {
       </Flex>
     </Toolbar>
   );
-};
+});

--- a/packages/editor/src/components/editor/canvas/Canvas.css
+++ b/packages/editor/src/components/editor/canvas/Canvas.css
@@ -37,6 +37,16 @@
   height: 1px;
 }
 
+.drag-hint {
+  margin: 0px;
+  padding: 5px;
+  border-radius: var(--border-r2);
+  color: var(--N800);
+}
+.drag-hint.column {
+  padding: 30px;
+}
+
 .empty-block.for-layout {
   height: var(--size-4);
 }

--- a/packages/editor/src/components/editor/canvas/Canvas.tsx
+++ b/packages/editor/src/components/editor/canvas/Canvas.tsx
@@ -5,6 +5,8 @@ import { useAppContext } from '../../../context/useData';
 import { DropZone, type DropZoneProps } from './DropZone';
 import type { Component, ComponentData } from '@axonivy/form-editor-protocol';
 import { CANVAS_DROPZONE_ID } from '../../../data/data';
+import { EmptyDetail } from '@axonivy/ui-components';
+import { useDndContext } from '@dnd-kit/core';
 
 type CanvasProps = {
   config: Config;
@@ -12,12 +14,18 @@ type CanvasProps = {
 
 export const Canvas = ({ config }: CanvasProps) => {
   const { ui, data } = useAppContext();
+  const { droppableContainers } = useDndContext();
+
   return (
     <div className='canvas' data-help-paddings={ui.helpPaddings} data-responsive-mode={ui.responsiveMode}>
       {data.components.map((component, index) => (
         <ComponentBlock key={component.id} component={component} config={config} preId={data.components.at(index - 1)?.id} />
       ))}
-      <EmtpyBlock id={CANVAS_DROPZONE_ID} preId={data.components.at(-1)?.id ?? ''} />
+      <EmtpyBlock
+        id={CANVAS_DROPZONE_ID}
+        preId={data.components.at(-1)?.id ?? ''}
+        dragHint={{ display: droppableContainers.size === 1, message: 'Drag first element inside the canvase', mode: 'column' }}
+      />
     </div>
   );
 };
@@ -34,8 +42,19 @@ export const ComponentBlock = ({ component, config, preId, ...props }: Component
   </DropZone>
 );
 
-export const EmtpyBlock = ({ id, preId, forLayout }: { id: string; preId: string; forLayout?: boolean }) => (
+type EmptyBlockProps = {
+  id: string;
+  preId: string;
+  forLayout?: boolean;
+  dragHint?: { display: boolean; mode: 'row' | 'column'; message: string };
+};
+
+export const EmtpyBlock = ({ id, preId, forLayout, dragHint }: EmptyBlockProps) => (
   <DropZone id={id} preId={preId}>
-    <div className={`empty-block${forLayout ? ' for-layout' : ''}`} />
+    {dragHint?.display ? (
+      <EmptyDetail message={dragHint.message} mode={dragHint.mode} className={`drag-hint ${dragHint.mode === 'column' ? 'column' : ''}`} />
+    ) : (
+      <div className={`empty-block${forLayout ? ' for-layout' : ''}`} />
+    )}
   </DropZone>
 );

--- a/packages/editor/src/components/editor/canvas/Draggable.css
+++ b/packages/editor/src/components/editor/canvas/Draggable.css
@@ -4,10 +4,13 @@
   border-radius: var(--border-r2);
   margin: var(--draw-margin);
 }
-.draggable:hover:not(:has(.draggable:hover)) {
+
+.draggable:hover:not(:has(.draggable:hover)),
+.draggable:hover:not(:has(.draggable:hover)) > .block-layout > div {
   background-color: var(--P50);
   border: 2px dashed var(--P75);
 }
+
 .draggable.selected,
 .draggable.dragging {
   border: 2px dashed var(--P75);

--- a/packages/editor/src/components/editor/canvas/Draggable.tsx
+++ b/packages/editor/src/components/editor/canvas/Draggable.tsx
@@ -29,13 +29,14 @@ export const Draggable = ({ config, data }: DraggableProps) => {
       onKeyUp={e => {
         e.stopPropagation();
         if (e.key === 'Delete') {
-          setData(oldData => modifyData(oldData, { type: 'remove', data: { id: data.id } }));
+          setData(oldData => modifyData(oldData, { type: 'remove', data: { id: data.id } }).newData);
+          appContext.setSelectedElement(undefined);
         }
         if (e.key === 'ArrowUp') {
-          setData(oldData => modifyData(oldData, { type: 'moveUp', data: { id: data.id } }));
+          setData(oldData => modifyData(oldData, { type: 'moveUp', data: { id: data.id } }).newData);
         }
         if (e.key === 'ArrowDown') {
-          setData(oldData => modifyData(oldData, { type: 'moveDown', data: { id: data.id } }));
+          setData(oldData => modifyData(oldData, { type: 'moveDown', data: { id: data.id } }).newData);
         }
       }}
       className={`draggable${isSelected ? ' selected' : ''}${isDragging ? ' dragging' : ''}`}

--- a/packages/editor/src/components/editor/canvas/DropZone.css
+++ b/packages/editor/src/components/editor/canvas/DropZone.css
@@ -7,7 +7,16 @@
   height: 0;
   transition: height 0.1s ease-out;
 }
+.drop-zone.is-drop-target:has(.drag-hint) .drop-zone-block {
+  height: 0;
+}
+
 .drop-zone.is-drop-target > .drop-zone-block {
   background: var(--P300);
   height: 4px;
+}
+
+.drop-zone.is-drop-target > .drag-hint {
+  background: var(--P300);
+  color: var(--background);
 }

--- a/packages/editor/src/components/editor/canvas/DropZone.tsx
+++ b/packages/editor/src/components/editor/canvas/DropZone.tsx
@@ -6,6 +6,7 @@ import { isDropZoneDisabled } from './drag-data';
 export type DropZoneProps = ComponentProps<'div'> & {
   id: string;
   preId?: string;
+  dragHint?: boolean;
 };
 
 export const DropZone = ({ id, preId, className, children }: DropZoneProps) => {

--- a/packages/editor/src/components/editor/properties/Properties.tsx
+++ b/packages/editor/src/components/editor/properties/Properties.tsx
@@ -55,7 +55,7 @@ const visibleSections = (fields: ReturnType<typeof visibleFields>, parent?: Comp
 export const Properties = ({ config }: PropertiesProps) => {
   const { element, setElement, parent } = useData();
   if (element === undefined) {
-    return <EmptyDetail message='Nothing there yet. Select an Element to edit its properties.' />;
+    return <EmptyDetail message='Nothing there yet. Select an Element to edit its properties.' mode='column' />;
   }
   const propertyConfig = config.components[element.type];
   if (propertyConfig === undefined || propertyConfig.fields === undefined) {

--- a/packages/editor/src/context/DndContext.tsx
+++ b/packages/editor/src/context/DndContext.tsx
@@ -36,11 +36,20 @@ export const DndContext = ({ children }: { children: ReactNode }) => {
 
   const handleDragEnd = (event: DragEndEvent) => {
     const targetId = event.over?.id;
-
     if (targetId && activeId) {
-      setData(oldData => modifyData(oldData, { type: 'dnd', data: { activeId, targetId } }));
+      setData(oldData => {
+        const modifiedData = modifyData(oldData, { type: 'dnd', data: { activeId, targetId } });
+        const newData = modifiedData.newData;
+        const newComponentId = modifiedData.newComponentId;
+        if (newComponentId) {
+          setSelectedElement(newComponentId);
+          setActiveId(newComponentId);
+        } else {
+          setSelectedElement(activeId);
+        }
+        return newData;
+      });
     }
-    setActiveId(undefined);
   };
 
   const handleDragStart = (event: DragStartEvent) => {

--- a/packages/editor/src/data/data.test.ts
+++ b/packages/editor/src/data/data.test.ts
@@ -23,11 +23,11 @@ describe('findComponentElement', () => {
 describe('modifyData', () => {
   describe('drag and drop', () => {
     test('add unknown', () => {
-      expect(modifyData(emptyData(), { type: 'dnd', data: { activeId: 'unknown', targetId: '' } })).to.deep.equals(emptyData());
+      expect(modifyData(emptyData(), { type: 'dnd', data: { activeId: 'unknown', targetId: '' } }).newData).to.deep.equals(emptyData());
     });
 
     test('add one', () => {
-      const data = modifyData(emptyData(), { type: 'dnd', data: { activeId: 'Input', targetId: '' } });
+      const data = modifyData(emptyData(), { type: 'dnd', data: { activeId: 'Input', targetId: '' } }).newData;
       expect(data).to.not.deep.equals(emptyData);
       expect(data.components).to.have.length(1);
       expect(data.components[0].id).to.match(/^Input-/);
@@ -36,17 +36,17 @@ describe('modifyData', () => {
     });
 
     test('add two', () => {
-      let data = modifyData(emptyData(), { type: 'dnd', data: { activeId: 'Input', targetId: '' } });
-      data = modifyData(data, { type: 'dnd', data: { activeId: 'Button', targetId: '' } });
+      let data = modifyData(emptyData(), { type: 'dnd', data: { activeId: 'Input', targetId: '' } }).newData;
+      data = modifyData(data, { type: 'dnd', data: { activeId: 'Button', targetId: '' } }).newData;
       expect(data).to.not.deep.equals(emptyData());
       expect(data.components).to.have.length(2);
       expect(data.components[1].type).to.equals('Button');
     });
 
     test('add deep', () => {
-      let data = modifyData(emptyData(), { type: 'dnd', data: { activeId: 'Layout', targetId: '' } });
-      data = modifyData(data, { type: 'dnd', data: { activeId: 'Button', targetId: `layout-${data.components[0].id}` } });
-      data = modifyData(data, { type: 'dnd', data: { activeId: 'Text', targetId: `layout-${data.components[0].id}` } });
+      let data = modifyData(emptyData(), { type: 'dnd', data: { activeId: 'Layout', targetId: '' } }).newData;
+      data = modifyData(data, { type: 'dnd', data: { activeId: 'Button', targetId: `layout-${data.components[0].id}` } }).newData;
+      data = modifyData(data, { type: 'dnd', data: { activeId: 'Text', targetId: `layout-${data.components[0].id}` } }).newData;
       expect(data).to.not.deep.equals(emptyData());
       expect(data.components).to.have.length(1);
       const layoutData = data.components[0].config.components as ComponentData[];
@@ -57,38 +57,38 @@ describe('modifyData', () => {
 
     test('move down', () => {
       const data = filledData();
-      expectOrder(modifyData(data, { type: 'dnd', data: { activeId: '1', targetId: '2' } }), ['1', '2', '3']);
-      expectOrder(modifyData(data, { type: 'dnd', data: { activeId: '1', targetId: '3' } }), ['2', '1', '3']);
-      expectOrder(modifyData(data, { type: 'dnd', data: { activeId: '1', targetId: '4' } }), ['2', '3', '1']);
+      expectOrder(modifyData(data, { type: 'dnd', data: { activeId: '1', targetId: '2' } }).newData, ['1', '2', '3']);
+      expectOrder(modifyData(data, { type: 'dnd', data: { activeId: '1', targetId: '3' } }).newData, ['2', '1', '3']);
+      expectOrder(modifyData(data, { type: 'dnd', data: { activeId: '1', targetId: '4' } }).newData, ['2', '3', '1']);
     });
 
     test('move down deep', () => {
-      const data = modifyData(filledData(), { type: 'dnd', data: { activeId: '31', targetId: '33' } });
+      const data = modifyData(filledData(), { type: 'dnd', data: { activeId: '31', targetId: '33' } }).newData;
       expectOrder(data, ['1', '2', '3']);
       expectOrderDeep(data, '3', ['32', '31', '33']);
     });
 
     test('move up', () => {
       const data = filledData();
-      expectOrder(modifyData(data, { type: 'dnd', data: { activeId: '3', targetId: '3' } }), ['1', '2', '3']);
-      expectOrder(modifyData(data, { type: 'dnd', data: { activeId: '3', targetId: '2' } }), ['1', '3', '2']);
-      expectOrder(modifyData(data, { type: 'dnd', data: { activeId: '3', targetId: '1' } }), ['3', '1', '2']);
+      expectOrder(modifyData(data, { type: 'dnd', data: { activeId: '3', targetId: '3' } }).newData, ['1', '2', '3']);
+      expectOrder(modifyData(data, { type: 'dnd', data: { activeId: '3', targetId: '2' } }).newData, ['1', '3', '2']);
+      expectOrder(modifyData(data, { type: 'dnd', data: { activeId: '3', targetId: '1' } }).newData, ['3', '1', '2']);
     });
 
     test('move up deep', () => {
-      const data = modifyData(filledData(), { type: 'dnd', data: { activeId: '33', targetId: '32' } });
+      const data = modifyData(filledData(), { type: 'dnd', data: { activeId: '33', targetId: '32' } }).newData;
       expectOrder(data, ['1', '2', '3']);
       expectOrderDeep(data, '3', ['31', '33', '32']);
     });
 
     test('move down to deep', () => {
-      const data = modifyData(filledData(), { type: 'dnd', data: { activeId: '1', targetId: '32' } });
+      const data = modifyData(filledData(), { type: 'dnd', data: { activeId: '1', targetId: '32' } }).newData;
       expectOrder(data, ['2', '3']);
       expectOrderDeep(data, '3', ['31', '1', '32', '33']);
     });
 
     test('move up from deep', () => {
-      const data = modifyData(filledData(), { type: 'dnd', data: { activeId: '32', targetId: '2' } });
+      const data = modifyData(filledData(), { type: 'dnd', data: { activeId: '32', targetId: '2' } }).newData;
       expectOrder(data, ['1', '32', '2', '3']);
       expectOrderDeep(data, '3', ['31', '33']);
     });
@@ -97,13 +97,13 @@ describe('modifyData', () => {
   describe('remove', () => {
     test('remove', () => {
       const data = filledData();
-      expectOrder(modifyData(data, { type: 'remove', data: { id: '1' } }), ['2', '3']);
-      expectOrder(modifyData(data, { type: 'remove', data: { id: '2' } }), ['1', '3']);
-      expectOrder(modifyData(data, { type: 'remove', data: { id: '3' } }), ['1', '2']);
+      expectOrder(modifyData(data, { type: 'remove', data: { id: '1' } }).newData, ['2', '3']);
+      expectOrder(modifyData(data, { type: 'remove', data: { id: '2' } }).newData, ['1', '3']);
+      expectOrder(modifyData(data, { type: 'remove', data: { id: '3' } }).newData, ['1', '2']);
     });
 
     test('remove deep', () => {
-      const removeDeep = modifyData(filledData(), { type: 'remove', data: { id: '32' } });
+      const removeDeep = modifyData(filledData(), { type: 'remove', data: { id: '32' } }).newData;
       expectOrder(removeDeep, ['1', '2', '3']);
       expectOrderDeep(removeDeep, '3', ['31', '33']);
     });
@@ -112,28 +112,28 @@ describe('modifyData', () => {
   describe('move', () => {
     test('down', () => {
       const data = filledData();
-      expectOrder(modifyData(data, { type: 'moveDown', data: { id: '2' } }), ['1', '3', '2']);
+      expectOrder(modifyData(data, { type: 'moveDown', data: { id: '2' } }).newData, ['1', '3', '2']);
     });
 
     test('down deep', () => {
       const data = filledData();
-      expectOrderDeep(modifyData(data, { type: 'moveDown', data: { id: '31' } }), '3', ['32', '31', '33']);
+      expectOrderDeep(modifyData(data, { type: 'moveDown', data: { id: '31' } }).newData, '3', ['32', '31', '33']);
     });
 
     test('up', () => {
       const data = filledData();
-      expectOrder(modifyData(data, { type: 'moveUp', data: { id: '2' } }), ['2', '1', '3']);
+      expectOrder(modifyData(data, { type: 'moveUp', data: { id: '2' } }).newData, ['2', '1', '3']);
     });
 
     test('up deep', () => {
       const data = filledData();
-      expectOrderDeep(modifyData(data, { type: 'moveUp', data: { id: '33' } }), '3', ['31', '33', '32']);
+      expectOrderDeep(modifyData(data, { type: 'moveUp', data: { id: '33' } }).newData, '3', ['31', '33', '32']);
     });
 
     test('first and last', () => {
       const data = filledData();
-      expectOrder(modifyData(data, { type: 'moveUp', data: { id: '1' } }), ['1', '2', '3']);
-      expectOrder(modifyData(data, { type: 'moveDown', data: { id: '3' } }), ['1', '2', '3']);
+      expectOrder(modifyData(data, { type: 'moveUp', data: { id: '1' } }).newData, ['1', '2', '3']);
+      expectOrder(modifyData(data, { type: 'moveDown', data: { id: '3' } }).newData, ['1', '2', '3']);
     });
   });
 });


### PR DESCRIPTION
In this PR I have improved the following things:
- Design layout component: It is now (hopefully) a bit clearer where the different boxes are in the grid.
- If the canvas is still empty, an Empty hint appears
- If the layout is still empty, an empty hint appears
- If no element is selected, the properties sidebar closes and if one is selected, it opens
- If an element is dropped to a new location, it remains selected. If an element is dragged into the canvas, it is selected immediately. (The only thing that does not yet work there is when a new element is dragged into a layout component. I would look at this in another PR)

![improve4444](https://github.com/user-attachments/assets/5dab259a-4400-4327-a070-3b1fe170474f)
