### PR TITLE
Improve selected when inserted

### DIFF
--- a/packages/editor/src/components/editor/canvas/Draggable.tsx
+++ b/packages/editor/src/components/editor/canvas/Draggable.tsx
@@ -29,13 +29,14 @@ export const Draggable = ({ config, data }: DraggableProps) => {
       onKeyUp={e => {
         e.stopPropagation();
         if (e.key === 'Delete') {
-          setData(oldData => modifyData(oldData, { type: 'remove', data: { id: data.id } }));
+          setData(oldData => modifyData(oldData, { type: 'remove', data: { id: data.id } }).newData);
+          appContext.setSelectedElement(undefined);
         }
         if (e.key === 'ArrowUp') {
-          setData(oldData => modifyData(oldData, { type: 'moveUp', data: { id: data.id } }));
+          setData(oldData => modifyData(oldData, { type: 'moveUp', data: { id: data.id } }).newData);
         }
         if (e.key === 'ArrowDown') {
-          setData(oldData => modifyData(oldData, { type: 'moveDown', data: { id: data.id } }));
+          setData(oldData => modifyData(oldData, { type: 'moveDown', data: { id: data.id } }).newData);
         }
       }}
       className={`draggable${isSelected ? ' selected' : ''}${isDragging ? ' dragging' : ''}`}

--- a/packages/editor/src/context/DndContext.tsx
+++ b/packages/editor/src/context/DndContext.tsx
@@ -15,7 +15,6 @@ import { useState, type ReactNode } from 'react';
 import { useData } from './useData';
 import { modifyData } from '../data/data';
 import { ItemDragOverlay } from '../components/editor/ItemDragOverlay';
-import type { ComponentData } from '@axonivy/form-editor-protocol';
 
 const ownCollisionDetection: CollisionDetection = ({ droppableContainers, ...args }) => {
   const rectIntersectionCollisions = rectIntersection({
@@ -31,11 +30,6 @@ const ownCollisionDetection: CollisionDetection = ({ droppableContainers, ...arg
   return pointerWithin({ droppableContainers, ...args });
 };
 
-const findNewComponent = (oldComponents: ComponentData[], newComponents: ComponentData[]) => {
-  const oldIds = new Set(oldComponents.map(component => component.id));
-  return newComponents.find(component => !oldIds.has(component.id));
-};
-
 export const DndContext = ({ children }: { children: ReactNode }) => {
   const { setData, setSelectedElement } = useData();
   const [activeId, setActiveId] = useState<string | undefined>();
@@ -44,11 +38,12 @@ export const DndContext = ({ children }: { children: ReactNode }) => {
     const targetId = event.over?.id;
     if (targetId && activeId) {
       setData(oldData => {
-        const newData = modifyData(oldData, { type: 'dnd', data: { activeId, targetId } });
-        const newComponent = findNewComponent(oldData.components, newData.components);
-        if (newComponent) {
-          setSelectedElement(newComponent.id);
-          setActiveId(newComponent.id);
+        const modifiedData = modifyData(oldData, { type: 'dnd', data: { activeId, targetId } });
+        const newData = modifiedData.newData;
+        const newComponentId = modifiedData.newComponentId;
+        if (newComponentId) {
+          setSelectedElement(newComponentId);
+          setActiveId(newComponentId);
         } else {
           setSelectedElement(activeId);
         }

--- a/packages/editor/src/data/data.test.ts
+++ b/packages/editor/src/data/data.test.ts
@@ -23,11 +23,11 @@ describe('findComponentElement', () => {
 describe('modifyData', () => {
   describe('drag and drop', () => {
     test('add unknown', () => {
-      expect(modifyData(emptyData(), { type: 'dnd', data: { activeId: 'unknown', targetId: '' } })).to.deep.equals(emptyData());
+      expect(modifyData(emptyData(), { type: 'dnd', data: { activeId: 'unknown', targetId: '' } }).newData).to.deep.equals(emptyData());
     });
 
     test('add one', () => {
-      const data = modifyData(emptyData(), { type: 'dnd', data: { activeId: 'Input', targetId: '' } });
+      const data = modifyData(emptyData(), { type: 'dnd', data: { activeId: 'Input', targetId: '' } }).newData;
       expect(data).to.not.deep.equals(emptyData);
       expect(data.components).to.have.length(1);
       expect(data.components[0].id).to.match(/^Input-/);
@@ -36,17 +36,17 @@ describe('modifyData', () => {
     });
 
     test('add two', () => {
-      let data = modifyData(emptyData(), { type: 'dnd', data: { activeId: 'Input', targetId: '' } });
-      data = modifyData(data, { type: 'dnd', data: { activeId: 'Button', targetId: '' } });
+      let data = modifyData(emptyData(), { type: 'dnd', data: { activeId: 'Input', targetId: '' } }).newData;
+      data = modifyData(data, { type: 'dnd', data: { activeId: 'Button', targetId: '' } }).newData;
       expect(data).to.not.deep.equals(emptyData());
       expect(data.components).to.have.length(2);
       expect(data.components[1].type).to.equals('Button');
     });
 
     test('add deep', () => {
-      let data = modifyData(emptyData(), { type: 'dnd', data: { activeId: 'Layout', targetId: '' } });
-      data = modifyData(data, { type: 'dnd', data: { activeId: 'Button', targetId: `layout-${data.components[0].id}` } });
-      data = modifyData(data, { type: 'dnd', data: { activeId: 'Text', targetId: `layout-${data.components[0].id}` } });
+      let data = modifyData(emptyData(), { type: 'dnd', data: { activeId: 'Layout', targetId: '' } }).newData;
+      data = modifyData(data, { type: 'dnd', data: { activeId: 'Button', targetId: `layout-${data.components[0].id}` } }).newData;
+      data = modifyData(data, { type: 'dnd', data: { activeId: 'Text', targetId: `layout-${data.components[0].id}` } }).newData;
       expect(data).to.not.deep.equals(emptyData());
       expect(data.components).to.have.length(1);
       const layoutData = data.components[0].config.components as ComponentData[];
@@ -57,38 +57,38 @@ describe('modifyData', () => {
 
     test('move down', () => {
       const data = filledData();
-      expectOrder(modifyData(data, { type: 'dnd', data: { activeId: '1', targetId: '2' } }), ['1', '2', '3']);
-      expectOrder(modifyData(data, { type: 'dnd', data: { activeId: '1', targetId: '3' } }), ['2', '1', '3']);
-      expectOrder(modifyData(data, { type: 'dnd', data: { activeId: '1', targetId: '4' } }), ['2', '3', '1']);
+      expectOrder(modifyData(data, { type: 'dnd', data: { activeId: '1', targetId: '2' } }).newData, ['1', '2', '3']);
+      expectOrder(modifyData(data, { type: 'dnd', data: { activeId: '1', targetId: '3' } }).newData, ['2', '1', '3']);
+      expectOrder(modifyData(data, { type: 'dnd', data: { activeId: '1', targetId: '4' } }).newData, ['2', '3', '1']);
     });
 
     test('move down deep', () => {
-      const data = modifyData(filledData(), { type: 'dnd', data: { activeId: '31', targetId: '33' } });
+      const data = modifyData(filledData(), { type: 'dnd', data: { activeId: '31', targetId: '33' } }).newData;
       expectOrder(data, ['1', '2', '3']);
       expectOrderDeep(data, '3', ['32', '31', '33']);
     });
 
     test('move up', () => {
       const data = filledData();
-      expectOrder(modifyData(data, { type: 'dnd', data: { activeId: '3', targetId: '3' } }), ['1', '2', '3']);
-      expectOrder(modifyData(data, { type: 'dnd', data: { activeId: '3', targetId: '2' } }), ['1', '3', '2']);
-      expectOrder(modifyData(data, { type: 'dnd', data: { activeId: '3', targetId: '1' } }), ['3', '1', '2']);
+      expectOrder(modifyData(data, { type: 'dnd', data: { activeId: '3', targetId: '3' } }).newData, ['1', '2', '3']);
+      expectOrder(modifyData(data, { type: 'dnd', data: { activeId: '3', targetId: '2' } }).newData, ['1', '3', '2']);
+      expectOrder(modifyData(data, { type: 'dnd', data: { activeId: '3', targetId: '1' } }).newData, ['3', '1', '2']);
     });
 
     test('move up deep', () => {
-      const data = modifyData(filledData(), { type: 'dnd', data: { activeId: '33', targetId: '32' } });
+      const data = modifyData(filledData(), { type: 'dnd', data: { activeId: '33', targetId: '32' } }).newData;
       expectOrder(data, ['1', '2', '3']);
       expectOrderDeep(data, '3', ['31', '33', '32']);
     });
 
     test('move down to deep', () => {
-      const data = modifyData(filledData(), { type: 'dnd', data: { activeId: '1', targetId: '32' } });
+      const data = modifyData(filledData(), { type: 'dnd', data: { activeId: '1', targetId: '32' } }).newData;
       expectOrder(data, ['2', '3']);
       expectOrderDeep(data, '3', ['31', '1', '32', '33']);
     });
 
     test('move up from deep', () => {
-      const data = modifyData(filledData(), { type: 'dnd', data: { activeId: '32', targetId: '2' } });
+      const data = modifyData(filledData(), { type: 'dnd', data: { activeId: '32', targetId: '2' } }).newData;
       expectOrder(data, ['1', '32', '2', '3']);
       expectOrderDeep(data, '3', ['31', '33']);
     });
@@ -97,13 +97,13 @@ describe('modifyData', () => {
   describe('remove', () => {
     test('remove', () => {
       const data = filledData();
-      expectOrder(modifyData(data, { type: 'remove', data: { id: '1' } }), ['2', '3']);
-      expectOrder(modifyData(data, { type: 'remove', data: { id: '2' } }), ['1', '3']);
-      expectOrder(modifyData(data, { type: 'remove', data: { id: '3' } }), ['1', '2']);
+      expectOrder(modifyData(data, { type: 'remove', data: { id: '1' } }).newData, ['2', '3']);
+      expectOrder(modifyData(data, { type: 'remove', data: { id: '2' } }).newData, ['1', '3']);
+      expectOrder(modifyData(data, { type: 'remove', data: { id: '3' } }).newData, ['1', '2']);
     });
 
     test('remove deep', () => {
-      const removeDeep = modifyData(filledData(), { type: 'remove', data: { id: '32' } });
+      const removeDeep = modifyData(filledData(), { type: 'remove', data: { id: '32' } }).newData;
       expectOrder(removeDeep, ['1', '2', '3']);
       expectOrderDeep(removeDeep, '3', ['31', '33']);
     });
@@ -112,28 +112,28 @@ describe('modifyData', () => {
   describe('move', () => {
     test('down', () => {
       const data = filledData();
-      expectOrder(modifyData(data, { type: 'moveDown', data: { id: '2' } }), ['1', '3', '2']);
+      expectOrder(modifyData(data, { type: 'moveDown', data: { id: '2' } }).newData, ['1', '3', '2']);
     });
 
     test('down deep', () => {
       const data = filledData();
-      expectOrderDeep(modifyData(data, { type: 'moveDown', data: { id: '31' } }), '3', ['32', '31', '33']);
+      expectOrderDeep(modifyData(data, { type: 'moveDown', data: { id: '31' } }).newData, '3', ['32', '31', '33']);
     });
 
     test('up', () => {
       const data = filledData();
-      expectOrder(modifyData(data, { type: 'moveUp', data: { id: '2' } }), ['2', '1', '3']);
+      expectOrder(modifyData(data, { type: 'moveUp', data: { id: '2' } }).newData, ['2', '1', '3']);
     });
 
     test('up deep', () => {
       const data = filledData();
-      expectOrderDeep(modifyData(data, { type: 'moveUp', data: { id: '33' } }), '3', ['31', '33', '32']);
+      expectOrderDeep(modifyData(data, { type: 'moveUp', data: { id: '33' } }).newData, '3', ['31', '33', '32']);
     });
 
     test('first and last', () => {
       const data = filledData();
-      expectOrder(modifyData(data, { type: 'moveUp', data: { id: '1' } }), ['1', '2', '3']);
-      expectOrder(modifyData(data, { type: 'moveDown', data: { id: '3' } }), ['1', '2', '3']);
+      expectOrder(modifyData(data, { type: 'moveUp', data: { id: '1' } }).newData, ['1', '2', '3']);
+      expectOrder(modifyData(data, { type: 'moveDown', data: { id: '3' } }).newData, ['1', '2', '3']);
     });
   });
 });


### PR DESCRIPTION
I'm not quite sure if this is so elegant to simply return newComponentId as another object via modifyData, as I still have to do ".newData" when calling the method.

![improve_selected](https://github.com/user-attachments/assets/4535cb30-4731-47e9-aa99-394033854693)
