### PR TITLE
XIVY-14725 Add additional properties-fields for select-component

### DIFF
--- a/packages/editor/src/components/blocks/select/Select.tsx
+++ b/packages/editor/src/components/blocks/select/Select.tsx
@@ -11,8 +11,10 @@ type SelectProps = Prettify<Select>;
 export const defaultInputProps: Select = {
   label: 'Label',
   value: '',
-  items: [],
-  itemsValue: '',
+  staticItems: [],
+  dynamicItemsList: '',
+  dynamicItemsLabel: '',
+  dynamicItemsValue: '',
   ...defaultBaseComponent
 } as const;
 
@@ -28,12 +30,24 @@ export const SelectComponent: ComponentConfig<SelectProps> = {
   fields: {
     label: { subsection: 'General', label: 'Label', type: 'text' },
     value: { subsection: 'General', label: 'Value', type: 'textBrowser' },
-    items: { subsection: 'Static Options', label: '', type: 'selectTable' },
-    itemsValue: {
+    staticItems: { subsection: 'Static Options', label: '', type: 'selectTable' },
+    dynamicItemsList: {
       subsection: 'Dynamic Options',
       label: 'List of Objects',
       type: 'textBrowser',
       options: { displayOnlyListTypes: true, placeholder: 'e.g. #{data.dynamicList}' }
+    },
+    dynamicItemsLabel: {
+      subsection: 'Dynamic Options',
+      label: 'Dynamic Label',
+      type: 'text',
+      options: { placeholder: 'Enter fitting attribute' }
+    },
+    dynamicItemsValue: {
+      subsection: 'Dynamic Options',
+      label: 'Dynamic Value',
+      type: 'text',
+      options: { placeholder: 'Enter fitting attribute or object' }
     },
     ...baseComponentFields
   }

--- a/packages/protocol/src/data/form.ts
+++ b/packages/protocol/src/data/form.ts
@@ -65,11 +65,13 @@ export interface Link {
   name: string;
 }
 export interface Select {
-  items: SelectItem[];
-  itemsValue: string;
+  dynamicItemsLabel: string;
+  dynamicItemsList: string;
+  dynamicItemsValue: string;
   label: string;
   lgSpan: string;
   mdSpan: string;
+  staticItems: SelectItem[];
   value: string;
 }
 export interface SelectItem {


### PR DESCRIPTION
I have now added the two new properties of the select component in the form editor.

At the moment they are just normal input fields and I don't think the end user can figure out what to type here. Accordingly, a select or browser would certainly be needed here (I think select is easiest for the user). But this will be in the next PR.
![grafik](https://github.com/user-attachments/assets/971e94d0-d1cf-4368-b365-b7ecd637fa7c)
