### PR TITLE
XIVY-14725 Add AttributeBrowser to find attributes of type

### DIFF
--- a/packages/editor/src/components/blocks/select/Select.tsx
+++ b/packages/editor/src/components/blocks/select/Select.tsx
@@ -35,19 +35,21 @@ export const SelectComponent: ComponentConfig<SelectProps> = {
       subsection: 'Dynamic Options',
       label: 'List of Objects',
       type: 'textBrowser',
-      options: { displayOnlyListTypes: true, placeholder: 'e.g. #{data.dynamicList}' }
+      options: { onlyListTypes: true, placeholder: 'e.g. #{data.dynamicList}' }
     },
     dynamicItemsLabel: {
       subsection: 'Dynamic Options',
-      label: 'Dynamic Label',
-      type: 'text',
-      options: { placeholder: 'Enter fitting attribute' }
+      label: 'Object Label',
+      type: 'textBrowser',
+      options: { onlyAttributes: true, placeholder: 'Enter attribute (or leave blank to select entire object)' },
+      hide: data => data.dynamicItemsList.length == 0
     },
     dynamicItemsValue: {
       subsection: 'Dynamic Options',
-      label: 'Dynamic Value',
-      type: 'text',
-      options: { placeholder: 'Enter fitting attribute or object' }
+      label: 'Object Value',
+      type: 'textBrowser',
+      options: { onlyAttributes: true, placeholder: 'Enter attribute (or leave blank to select entire object)' },
+      hide: data => data.dynamicItemsList.length == 0
     },
     ...baseComponentFields
   }

--- a/packages/editor/src/data/variable-tree-data.test.ts
+++ b/packages/editor/src/data/variable-tree-data.test.ts
@@ -1,5 +1,5 @@
 import type { VariableInfo } from '@axonivy/form-editor-protocol';
-import { findListVariables, fullVariablePath, rowToCreateData, variableTreeData } from './variable-tree-data';
+import { findListVariables, findAttributesOfType, fullVariablePath, rowToCreateData, variableTreeData } from './variable-tree-data';
 import type { BrowserNode } from '@axonivy/ui-components';
 import type { Row } from '@tanstack/react-table';
 
@@ -128,11 +128,22 @@ describe('variableTreeData', () => {
   });
 });
 
-test('of endless', () => {
+test('findListVariable of endless', () => {
   const list = findListVariables(endlessParamInfo);
   expect(list.length).toEqual(1);
   expect(list[0].value).toEqual('param.Endless.endlessList');
   expect(list[0].info).toEqual('List<demo.Endless>');
+});
+
+test('findAttributesOfType of List<demo.Endless>', () => {
+  const list = findAttributesOfType(endlessParamInfo, 'param.Endless.endlessList');
+  expect(list.length).toEqual(1);
+  expect(list[0].value).toEqual('Use entire Object');
+  expect(list[0].info).toEqual('demo.Endless');
+  expect(list[0].children[0].value).toEqual('endless');
+  expect(list[0].children[0].info).toEqual('demo.Endless');
+  expect(list[0].children[2].value).toEqual('something');
+  expect(list[0].children[2].info).toEqual('String');
 });
 
 const row = {
@@ -142,6 +153,10 @@ const row = {
 
 test('fullVariablePath', () => {
   expect(fullVariablePath(row)).toEqual('data.address.location.country');
+});
+
+test('fullVariablePath dontShowRootNode', () => {
+  expect(fullVariablePath(row, true)).toEqual('address.location.country');
 });
 
 test('rowToCreateData', () => {

--- a/packages/editor/src/editor/properties/fields/InputFieldWithBrowser.tsx
+++ b/packages/editor/src/editor/properties/fields/InputFieldWithBrowser.tsx
@@ -13,7 +13,8 @@ export const InputFieldWithBrowser = ({
   options
 }: InputFieldProps & { options?: TextBrowserFieldOptions }) => {
   const [open, setOpen] = useState(false);
-  const attrBrowser = useAttributeBrowser(!!options?.displayOnlyListTypes);
+  const attrBrowser = useAttributeBrowser(!!options?.onlyListTypes, !!options?.onlyAttributes);
+
   return (
     <Dialog open={open} onOpenChange={setOpen}>
       <Fieldset label={label}>
@@ -29,7 +30,7 @@ export const InputFieldWithBrowser = ({
           browsers={[attrBrowser]}
           apply={(browserName, result) => {
             if (result) {
-              onChange(`#{${result.value}}`);
+              onChange(options?.onlyAttributes ? `${result.value}` : `#{${result.value}}`);
             }
             setOpen(false);
           }}

--- a/packages/editor/src/editor/properties/fields/browser/useAttributeBrowser.tsx
+++ b/packages/editor/src/editor/properties/fields/browser/useAttributeBrowser.tsx
@@ -1,28 +1,40 @@
 import { useBrowser, type Browser, type BrowserNode } from '@axonivy/ui-components';
 import { IvyIcons } from '@axonivy/ui-icons';
 import { useMeta } from '../../../../context/useMeta';
-import { findListVariables, fullVariablePath, variableTreeData } from '../../../../data/variable-tree-data';
+import { findListVariables, findAttributesOfType, fullVariablePath, variableTreeData } from '../../../../data/variable-tree-data';
 import { useCallback, useEffect, useState } from 'react';
 import type { Variable } from '@axonivy/form-editor-protocol';
 import { useAppContext } from '../../../../context/AppContext';
+import { useData } from '../../../../data/data';
 
 export const ATTRIBUTE_BROWSER_ID = 'Attribute' as const;
 
-export const useAttributeBrowser = (onlyList: Boolean): Browser => {
+export const useAttributeBrowser = (onlyListTypes: boolean, onlyAttributes: boolean): Browser => {
   const [tree, setTree] = useState<Array<BrowserNode<Variable>>>([]);
   const { context } = useAppContext();
   const variableInfo = useMeta('meta/data/attributes', context, { types: {}, variables: [] }).data;
-  useEffect(() => setTree(onlyList ? findListVariables(variableInfo) : variableTreeData().of(variableInfo)), [onlyList, variableInfo]);
+  const { element } = useData();
+  const dynamicList = element?.config.dynamicItemsList as string;
+  useEffect(() => {
+    if (onlyListTypes && !onlyAttributes) {
+      setTree(findListVariables(variableInfo));
+    } else if (!onlyListTypes && onlyAttributes) {
+      setTree(findAttributesOfType(variableInfo, dynamicList));
+    } else {
+      setTree(variableTreeData().of(variableInfo));
+    }
+  }, [onlyListTypes, onlyAttributes, variableInfo, dynamicList]);
+
   const loadChildren = useCallback<(row: BrowserNode) => void>(
     row => setTree(tree => variableTreeData().loadChildrenFor(variableInfo, row.info, tree)),
     [variableInfo, setTree]
   );
-  const attributes = useBrowser(tree, onlyList ? undefined : row => loadChildren(row.original));
+  const attributes = useBrowser(tree, onlyListTypes ? undefined : row => loadChildren(row.original));
   return {
     name: ATTRIBUTE_BROWSER_ID,
     icon: IvyIcons.Attribute,
     browser: attributes,
     infoProvider: row => row?.original.info,
-    applyModifier: row => ({ value: onlyList ? row.original.value : fullVariablePath(row) })
+    applyModifier: row => ({ value: onlyListTypes ? row.original.value : fullVariablePath(row, onlyAttributes) })
   };
 };

--- a/packages/editor/src/types/config.ts
+++ b/packages/editor/src/types/config.ts
@@ -34,7 +34,8 @@ export type TextFieldOptions = {
 };
 
 export type TextBrowserFieldOptions = TextFieldOptions & {
-  displayOnlyListTypes?: boolean;
+  onlyListTypes?: boolean;
+  onlyAttributes?: boolean;
 };
 
 export type TextField<ComponentProps extends DefaultComponentProps = DefaultComponentProps> = BaseField<ComponentProps> & {


### PR DESCRIPTION
I have now created a browser for the dynamic label and value, with which you can find the attributes from the type of the List of Objects selected above. If the field is left empty, the entire object is used (we check in the backend, if empty, the name inside var which is ‘variable’ is used).

![selectComponentFInal](https://github.com/user-attachments/assets/618daef5-5726-416e-9d37-9b978a353f89)
