### PR TITLE
XIVY-13645 Add DatePicker to createComp. & rename desciptions

### DIFF
--- a/packages/editor/src/components/blocks/combobox/Combobox.tsx
+++ b/packages/editor/src/components/blocks/combobox/Combobox.tsx
@@ -23,7 +23,7 @@ export const ComboboxComponent: ComponentConfig<ComboboxProps> = {
   category: 'Elements',
   subcategory: 'Interactions',
   icon: <IconSvg />,
-  description: 'A simple autocomplete Combobox',
+  description: 'A autocomplete combobox with label',
   defaultProps: defaultInputProps,
   render: props => <UiBlock {...props} />,
   create: ({ label, value, ...defaultProps }) => ({ ...defaultInputProps, label, value, ...defaultProps }),

--- a/packages/editor/src/components/blocks/datepicker/DatePicker.tsx
+++ b/packages/editor/src/components/blocks/datepicker/DatePicker.tsx
@@ -20,7 +20,7 @@ export const DatePickerComponent: ComponentConfig<DatePickerProps> = {
   category: 'Elements',
   subcategory: 'Interactions',
   icon: <IconSvg />,
-  description: 'A simple datepicker for Date or DateTime',
+  description: 'A datepicker with label for date or datetime',
   defaultProps: defaultInputProps,
   render: props => <UiBlock {...props} />,
   create: ({ label, value, ...defaultProps }) => ({ ...defaultInputProps, label, value, ...defaultProps }),

--- a/packages/editor/src/components/blocks/input/Input.tsx
+++ b/packages/editor/src/components/blocks/input/Input.tsx
@@ -26,7 +26,7 @@ export const InputComponent: ComponentConfig<InputProps> = {
   category: 'Elements',
   subcategory: 'Input',
   icon: <IconSvg />,
-  description: 'A simple input with a label',
+  description: 'A input with a label',
   defaultProps: defaultInputProps,
   render: props => <UiBlock {...props} />,
   create: ({ label, value, ...defaultProps }) => ({ ...defaultInputProps, label, value, ...defaultProps }),

--- a/packages/editor/src/components/blocks/radio/Radio.tsx
+++ b/packages/editor/src/components/blocks/radio/Radio.tsx
@@ -31,7 +31,7 @@ export const RadioComponent: ComponentConfig<RadioProps> = {
   category: 'Elements',
   subcategory: 'Interactions',
   icon: <IconSvg />,
-  description: 'A simple input with a label',
+  description: 'A radio button group with label for selecting a single option',
   defaultProps: defaultInputProps,
   render: props => <UiBlock {...props} />,
   create: ({ label, value, ...defaultProps }) => ({ ...defaultInputProps, label, value, ...defaultProps }),

--- a/packages/editor/src/components/blocks/select/Select.tsx
+++ b/packages/editor/src/components/blocks/select/Select.tsx
@@ -23,7 +23,7 @@ export const SelectComponent: ComponentConfig<SelectProps> = {
   category: 'Elements',
   subcategory: 'Interactions',
   icon: <IconSvg />,
-  description: 'A simple input with a label',
+  description: 'A dropdown menu with label for selecting a single option',
   defaultProps: defaultInputProps,
   render: props => <UiBlock {...props} />,
   create: ({ label, value, ...defaultProps }) => ({ ...defaultInputProps, label, value, ...defaultProps }),

--- a/packages/editor/src/components/blocks/textarea/Textarea.tsx
+++ b/packages/editor/src/components/blocks/textarea/Textarea.tsx
@@ -19,7 +19,7 @@ export const TextareaComponent: ComponentConfig<TextareaProps> = {
   category: 'Elements',
   subcategory: 'Input',
   icon: <IconSvg />,
-  description: 'A simple and customizable Textarea component',
+  description: 'A customizable Textarea component',
   defaultProps: defaultInputProps,
   render: props => <UiBlock {...props} />,
   create: ({ label, value, ...defaultProps }) => ({ ...defaultInputProps, label, value, ...defaultProps }),

--- a/packages/editor/src/components/components.test.ts
+++ b/packages/editor/src/components/components.test.ts
@@ -1,4 +1,5 @@
 import { CheckboxComponent } from './blocks/checkbox/Checkbox';
+import { DatePickerComponent } from './blocks/datepicker/DatePicker';
 import { InputComponent } from './blocks/input/Input';
 import { allComponentsByCategory, componentByName, componentForType, componentsByCategory } from './components';
 
@@ -26,8 +27,9 @@ test('componentForType', () => {
   expect(componentForType('String')).toEqual({ component: InputComponent });
   expect(componentForType('Number')).toEqual({ component: InputComponent, defaultProps: { type: 'NUMBER' } });
   expect(componentForType('Boolean')).toEqual({ component: CheckboxComponent });
-  expect(componentForType('Date')).toEqual(undefined);
-  expect(componentForType('DateTime')).toEqual(undefined);
+  expect(componentForType('Date')).toEqual({ component: DatePickerComponent });
+  expect(componentForType('DateTime')).toEqual({ component: DatePickerComponent });
+  expect(componentForType('java.util.Date')).toEqual({ component: DatePickerComponent });
   expect(componentForType('Time')).toEqual(undefined);
   expect(componentForType('File')).toEqual(undefined);
 });

--- a/packages/editor/src/components/components.ts
+++ b/packages/editor/src/components/components.ts
@@ -51,6 +51,12 @@ export const componentForType = (type: AutoCompleteWithString<ComponentType>) =>
       return { component: config.components.Input, defaultProps: { type: 'NUMBER' } };
     case 'Boolean':
       return { component: config.components.Checkbox };
+    case 'Date':
+      return { component: config.components.DatePicker };
+    case 'DateTime':
+      return { component: config.components.DatePicker };
+    case 'java.util.Date':
+      return { component: config.components.DatePicker };
     default:
       return undefined;
   }


### PR DESCRIPTION
- Added DatePicker to componentForType for automatic generation via data (toolbar) or 'Create from data'.
- Adjusted descriptions of individual components.

![grafik](https://github.com/user-attachments/assets/25c76301-394d-41da-adda-65e7f673004b)
