### PR TITLE
XIVY-13646 Add DataTable-Component

### DIFF
--- a/packages/editor/src/components/blocks/base.ts
+++ b/packages/editor/src/components/blocks/base.ts
@@ -45,7 +45,7 @@ export const selectItemsComponentFields: Fields<SelectItemsProps> = {
     label: 'Object Label',
     type: 'textBrowser',
     options: {
-      onlyAttributes: true,
+      onlyAttributes: 'DYNAMICLIST',
       placeholder: 'Enter attribute (or leave blank to select entire object)'
     },
     hide: data => data.dynamicItemsList.length == 0
@@ -55,7 +55,7 @@ export const selectItemsComponentFields: Fields<SelectItemsProps> = {
     label: 'Object Value',
     type: 'textBrowser',
     options: {
-      onlyAttributes: true,
+      onlyAttributes: 'DYNAMICLIST',
       placeholder: 'Enter attribute (or leave blank to select entire object)'
     },
     hide: data => data.dynamicItemsList.length == 0

--- a/packages/editor/src/components/blocks/datatable/DataTable.css
+++ b/packages/editor/src/components/blocks/datatable/DataTable.css
@@ -1,0 +1,32 @@
+.block-table {
+  gap: var(--size-4);
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+}
+
+.block-table__label {
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+  width: 100%;
+}
+
+.block-table__columns {
+  display: flex;
+  flex-direction: row;
+  gap: var(--size-1);
+}
+
+.block-table > div:not(.block-table__label) {
+  border: var(--layout-border-size, 1.5px) solid var(--N100);
+  border-radius: var(--border-r2);
+}
+
+.block-table > div > div {
+  border: none;
+}
+
+.selected > .block-table > div:not(.block-table__label) {
+  border: var(--layout-border-size, 1.5px) dashed var(--P75);
+}

--- a/packages/editor/src/components/blocks/datatable/DataTable.svg
+++ b/packages/editor/src/components/blocks/datatable/DataTable.svg
@@ -1,0 +1,17 @@
+<svg width="38" height="26" viewBox="0 0 38 26" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <g clip-path="url(#clip0_49_18)">
+        <path d="M19 1V25" stroke="#A3A3A3" stroke-width="1.55402" stroke-linecap="round" />
+        <path d="M10 1L10 25" stroke="#A3A3A3" stroke-width="1.55402" stroke-linecap="round" />
+        <path d="M28 1V25" stroke="#A3A3A3" stroke-width="1.55402" stroke-linecap="round" />
+        <path d="M1 1H37V7H1V1Z" fill="#A3A3A3" stroke="#A3A3A3" stroke-width="0.888776"
+            stroke-linecap="round" stroke-linejoin="round" />
+    </g>
+    <rect x="0.605172" y="0.605172" width="36.7897" height="24.7897" rx="1.33736" stroke="#A3A3A3"
+        stroke-width="1.21034" />
+    <defs>
+        <clipPath id="clip0_49_18">
+            <rect width="38" height="26" rx="1.94253" fill="white" />
+        </clipPath>
+    </defs>
+</svg>
+    

--- a/packages/editor/src/components/blocks/datatable/DataTable.tsx
+++ b/packages/editor/src/components/blocks/datatable/DataTable.tsx
@@ -1,0 +1,92 @@
+import type { DataTable, Prettify } from '@axonivy/form-editor-protocol';
+import type { ComponentConfig, UiComponentProps } from '../../../types/config';
+import './DataTable.css';
+import { baseComponentFields, defaultBaseComponent } from '../base';
+import IconSvg from './DataTable.svg?react';
+import { ComponentBlock } from '../../../editor/canvas/ComponentBlock';
+import { useAppContext } from '../../../context/AppContext';
+import { Button, Message } from '@axonivy/ui-components';
+import { useMeta } from '../../../context/useMeta';
+import { findAttributesOfType } from '../../../data/variable-tree-data';
+import { componentByName } from '../../components';
+import { createInitiTableColumns } from '../../../data/data';
+import { IvyIcons } from '@axonivy/ui-icons';
+
+type DataTableProps = Prettify<DataTable>;
+
+export const defaultDataTableProps: DataTable = {
+  components: [],
+  label: 'Label',
+  value: '',
+  ...defaultBaseComponent
+} as const;
+
+export const DataTableComponent: ComponentConfig<DataTableProps> = {
+  name: 'DataTable',
+  category: 'Elements',
+  subcategory: 'Input',
+  icon: <IconSvg />,
+  description: 'A datatable component',
+  defaultProps: defaultDataTableProps,
+  render: props => <UiBlock {...props} />,
+  create: ({ label, value, ...defaultProps }) => ({ ...defaultDataTableProps, label, value, ...defaultProps }),
+  outlineInfo: component => component.label,
+  fields: {
+    components: { subsection: 'General', type: 'hidden' },
+    label: { subsection: 'General', label: 'Label', type: 'text' },
+    value: { subsection: 'General', label: 'Value', type: 'textBrowser', options: { onlyTypesOf: 'List<' } },
+    ...baseComponentFields
+  }
+};
+
+const UiBlock = ({ id, label, components, value }: UiComponentProps<DataTableProps>) => (
+  <div className='block-table'>
+    <div className='block-table__label'>
+      <span>{label}</span>
+      <span style={{ color: 'var(--N600)' }}>{value.length > 0 ? value : 'value is empty'}</span>
+    </div>
+    {components.length > 0 && (
+      <div className='block-table__columns'>
+        {components.map((column, index) => (
+          <ComponentBlock key={column.id} component={column} preId={components[index - 1]?.id} />
+        ))}
+      </div>
+    )}
+    {components.length === 0 && <EmptyDataTableColumn id={id} initValue={value} />}
+  </div>
+);
+
+const EmptyDataTableColumn = ({ id, initValue }: { id: string; initValue: string }) => {
+  const { context, setData } = useAppContext();
+  const dataClass = useMeta('meta/data/attributes', context, { types: {}, variables: [] }).data;
+
+  if (initValue.length === 0) {
+    return <Message variant='warning' message='Value of DataTable is empty. Define value within Properties of DataTable' />;
+  }
+
+  const createColumns = () => {
+    const tree = findAttributesOfType(dataClass, initValue);
+    setData(data => {
+      const creates = tree[0].children
+        .map(attribute => {
+          const component = componentByName('DataTableColumn');
+          if (component === undefined) {
+            return undefined;
+          }
+          return {
+            componentName: component.name,
+            label: attribute.value,
+            value: attribute.value
+          };
+        })
+        .filter(create => create !== undefined);
+      return createInitiTableColumns(id, data, creates);
+    });
+  };
+
+  return (
+    <Button icon={IvyIcons.DatabaseLink} variant='outline' onClick={createColumns}>
+      Create columns from value
+    </Button>
+  );
+};

--- a/packages/editor/src/components/blocks/datatablecolumn/DataTableColumn.tsx
+++ b/packages/editor/src/components/blocks/datatablecolumn/DataTableColumn.tsx
@@ -1,0 +1,44 @@
+import type { DataTableColumn, Prettify } from '@axonivy/form-editor-protocol';
+import type { ComponentConfig, UiComponentProps } from '../../../types/config';
+import { baseComponentFields, defaultBaseComponent } from '../base';
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@axonivy/ui-components';
+
+type DataTableColumnProps = Prettify<DataTableColumn>;
+
+export const defaultDataTableColumnProps: DataTableColumn = {
+  header: 'header',
+  value: 'value',
+  ...defaultBaseComponent
+} as const;
+
+export const DataTableColumnComponent: ComponentConfig<DataTableColumnProps> = {
+  name: 'DataTableColumn',
+  category: 'Hidden',
+  subcategory: 'Input',
+  icon: '',
+  description: 'A Column for the DataTable',
+  defaultProps: defaultDataTableColumnProps,
+  render: props => <UiBlock {...props} />,
+  create: ({ label, value }) => ({ ...defaultDataTableColumnProps, header: label, value }),
+  outlineInfo: component => component.header,
+  fields: {
+    header: { subsection: 'General', label: 'Header', type: 'text' },
+    value: { subsection: 'General', label: 'Value', type: 'textBrowser', options: { onlyAttributes: 'COLUMN' } },
+    ...baseComponentFields
+  }
+};
+
+const UiBlock = ({ header, value }: UiComponentProps<DataTableColumnProps>) => (
+  <Table className='placeholder-table'>
+    <TableHeader>
+      <TableRow>
+        <TableHead style={{ fontWeight: 'bold' }}>{header}</TableHead>
+      </TableRow>
+    </TableHeader>
+    <TableBody>
+      <TableRow>
+        <TableCell>{value}</TableCell>
+      </TableRow>
+    </TableBody>
+  </Table>
+);

--- a/packages/editor/src/components/components.test.ts
+++ b/packages/editor/src/components/components.test.ts
@@ -11,15 +11,17 @@ test('componentByName', () => {
 test('componentByCategory', () => {
   const result = componentsByCategory('Elements');
   expect(result.General).toEqual(undefined);
-  expect(result.Input).toHaveLength(4);
+  expect(result.Input).toHaveLength(5);
   expect(result.Selection).toHaveLength(3);
   expect(result.Text).toHaveLength(1);
+  const resultHidden = componentsByCategory('Hidden');
+  expect(resultHidden.Input).toHaveLength(1);
 });
 
 test('allComponentsByCategory', () => {
   const result = allComponentsByCategory();
   expect(result.Action).toHaveLength(2);
-  expect(result.Elements).toHaveLength(8);
+  expect(result.Elements).toHaveLength(9);
   expect(result.Structure).toHaveLength(1);
 });
 

--- a/packages/editor/src/components/components.ts
+++ b/packages/editor/src/components/components.ts
@@ -13,6 +13,8 @@ import { ComboboxComponent } from './blocks/combobox/Combobox';
 import { RadioComponent } from './blocks/radio/Radio';
 import { DatePickerComponent } from './blocks/datepicker/DatePicker';
 import { TextareaComponent } from './blocks/textarea/Textarea';
+import { DataTableComponent } from './blocks/datatable/DataTable';
+import { DataTableColumnComponent } from './blocks/datatablecolumn/DataTableColumn';
 
 const config: Config = {
   components: {
@@ -26,14 +28,15 @@ const config: Config = {
     Text: TextComponent,
     Button: ButtonComponent,
     Link: LinkComponent,
-    Layout: LayoutComponent
+    Layout: LayoutComponent,
+    DataTable: DataTableComponent,
+    DataTableColumn: DataTableColumnComponent
   }
 } as const;
 
 export const componentByName = (name: AutoCompleteWithString<ComponentType>) => {
   return config.components[name];
 };
-//
 
 export const componentsByCategory = (category: ItemCategory) => {
   const filteredComponents = Object.values(config.components).filter(component => component.category === category);
@@ -41,7 +44,10 @@ export const componentsByCategory = (category: ItemCategory) => {
 };
 
 export const allComponentsByCategory = () => {
-  return groupBy(Object.values(config.components), item => item.category);
+  return groupBy(
+    Object.values(config.components).filter(component => component.category !== 'Hidden'),
+    item => item.category
+  );
 };
 
 export const componentForType = (type: AutoCompleteWithString<ComponentType>) => {

--- a/packages/editor/src/data/data.test.ts
+++ b/packages/editor/src/data/data.test.ts
@@ -1,5 +1,5 @@
-import { EMPTY_FORM, type ComponentData, type FormData, isLayout, type LayoutConfig } from '@axonivy/form-editor-protocol';
-import { createInitForm, DELETE_DROPZONE_ID, findComponentElement, modifyData } from './data';
+import { EMPTY_FORM, type ComponentData, type FormData, isLayout, type LayoutConfig, type DataTable } from '@axonivy/form-editor-protocol';
+import { createInitForm, DELETE_DROPZONE_ID, findComponentElement, findParentTableComponent, modifyData } from './data';
 import type { DeepPartial } from '../types/types';
 
 describe('findComponentElement', () => {
@@ -191,6 +191,46 @@ describe('createInitForm', () => {
     expect(layout.config.components).toHaveLength(2);
     expect(layout.config.components[0].config.action).toEqual('#{ivyWorkflowView.cancel()}');
     expect(layout.config.components[1].config.action).toEqual('#{logic.close}');
+  });
+});
+
+describe('findParentTableComponent', () => {
+  const dataTable: DeepPartial<DataTable> = {
+    components: [
+      { id: 'column-1', type: 'DataTableColumn', config: {} },
+      { id: 'column-2', type: 'DataTableColumn', config: {} }
+    ]
+  };
+
+  const data: ComponentData[] = [
+    {
+      id: '3',
+      type: 'DataTable',
+      config: { components: dataTable.components as ComponentData[] }
+    }
+  ];
+
+  test('return DataTable containing the element', () => {
+    const element: ComponentData = { id: 'column-1', type: 'DataTableColumn', config: {} };
+    expect(findParentTableComponent(data, element)).toEqual(dataTable);
+  });
+
+  test('return undefined if element is no Column', () => {
+    const element: ComponentData = { id: 'button', type: 'Button', config: {} };
+    expect(findParentTableComponent(data, element)).toBeUndefined();
+  });
+
+  test('return undefined if the element is undefined', () => {
+    expect(findParentTableComponent(data, undefined)).toBeUndefined();
+  });
+
+  test('return undefined if there are no DataTable components', () => {
+    const noTableData: ComponentData[] = [
+      { id: '1', type: 'Input', config: {} },
+      { id: '2', type: 'Button', config: {} }
+    ];
+    const element: ComponentData = { id: 'column-1', type: 'DataTableColumn', config: {} };
+    expect(findParentTableComponent(noTableData, element)).toBeUndefined();
   });
 });
 

--- a/packages/editor/src/editor/canvas/drag-data.ts
+++ b/packages/editor/src/editor/canvas/drag-data.ts
@@ -1,11 +1,11 @@
-import { isLayout, type Component, type ComponentData } from '@axonivy/form-editor-protocol';
+import { isLayout, isTable, type Component, type ComponentData } from '@axonivy/form-editor-protocol';
 import type { Active } from '@dnd-kit/core';
-import { LAYOUT_DROPZONE_ID_PREFIX } from '../../data/data';
+import { LAYOUT_DROPZONE_ID_PREFIX, TABLE_DROPZONE_ID_PREFIX } from '../../data/data';
 
 export type DragData = { disabledIds: Array<string> };
 
 const disabledIds = (data: Component | ComponentData): Array<string> => {
-  if (isLayout(data)) {
+  if (isLayout(data) || isTable(data)) {
     const ids: Array<string> = [];
     for (const component of data.config.components) {
       ids.push(...disabledIds(component));
@@ -26,7 +26,16 @@ export const isDragData = (data: unknown): data is DragData => {
 
 export const isDropZoneDisabled = (id: string, active: Active | null, preId?: string) => {
   const dropZoneId = active?.id;
-  if (dropZoneId === id || `${LAYOUT_DROPZONE_ID_PREFIX}${dropZoneId}` === id || dropZoneId === preId) {
+
+  if (disableDropZoneDataTableColumn(id, dropZoneId?.toString())) {
+    return true;
+  }
+  if (
+    dropZoneId === id ||
+    `${LAYOUT_DROPZONE_ID_PREFIX}${dropZoneId}` === id ||
+    `${TABLE_DROPZONE_ID_PREFIX}${dropZoneId}` === id ||
+    dropZoneId === preId
+  ) {
     return true;
   }
   const data = active?.data.current;
@@ -34,4 +43,14 @@ export const isDropZoneDisabled = (id: string, active: Active | null, preId?: st
     return data.disabledIds.includes(id);
   }
   return false;
+};
+
+const disableDropZoneDataTableColumn = (id: string, dropZoneId: string | undefined) => {
+  const isColumn = id.startsWith('DataTableColumn');
+  const isColumnTarget = dropZoneId ? dropZoneId.includes('DataTableColumn') : false;
+
+  if (isColumn) {
+    return !isColumnTarget;
+  }
+  return isColumnTarget;
 };

--- a/packages/editor/src/editor/sidebar/fields/InputFieldWithBrowser.tsx
+++ b/packages/editor/src/editor/sidebar/fields/InputFieldWithBrowser.tsx
@@ -13,7 +13,7 @@ export const InputFieldWithBrowser = ({
   options
 }: InputFieldProps & { options?: TextBrowserFieldOptions }) => {
   const [open, setOpen] = useState(false);
-  const attrBrowser = useAttributeBrowser(!!options?.onlyAttributes, options?.onlyTypesOf);
+  const attrBrowser = useAttributeBrowser(options?.onlyAttributes, options?.onlyTypesOf);
 
   return (
     <Dialog open={open} onOpenChange={setOpen}>

--- a/packages/editor/src/types/config.ts
+++ b/packages/editor/src/types/config.ts
@@ -33,9 +33,11 @@ export type TextFieldOptions = {
   placeholder?: string;
 };
 
+export type onlyAttributeSelection = 'DYNAMICLIST' | 'COLUMN';
+
 export type TextBrowserFieldOptions = TextFieldOptions & {
   onlyTypesOf?: string;
-  onlyAttributes?: boolean;
+  onlyAttributes?: onlyAttributeSelection;
 };
 
 export type TextField<ComponentProps extends DefaultComponentProps = DefaultComponentProps> = BaseField<ComponentProps> & {
@@ -71,7 +73,7 @@ export type Fields<ComponentProps extends DefaultComponentProps = DefaultCompone
   [PropName in keyof Omit<Required<ComponentProps>, 'children'>]: Field<ComponentProps>;
 };
 
-export type ItemCategory = 'Elements' | 'Structure' | 'Action';
+export type ItemCategory = 'Elements' | 'Structure' | 'Action' | 'Hidden';
 export type ItemSubcategory = 'General' | 'Input' | 'Selection' | 'Text';
 
 export type ComponentConfig<ComponentProps extends DefaultComponentProps = DefaultComponentProps, DefaultProps = ComponentProps> = {

--- a/packages/protocol/src/data/form-data.ts
+++ b/packages/protocol/src/data/form-data.ts
@@ -23,6 +23,10 @@ export const isLayout = (component?: Component | ComponentData): component is La
   return component !== undefined && component.type === 'Layout' && 'components' in component.config;
 };
 
+export const isTable = (component?: Component | ComponentData): component is LayoutConfig => {
+  return component !== undefined && component.type === 'DataTable' && 'components' in component.config;
+};
+
 export const isFreeLayout = (component?: Component | ComponentData): component is LayoutConfig => {
   return isLayout(component) && component.config.gridVariant === 'FREE';
 };

--- a/packages/protocol/src/data/form.ts
+++ b/packages/protocol/src/data/form.ts
@@ -30,6 +30,8 @@ export interface Component {
     | "Button"
     | "Checkbox"
     | "Combobox"
+    | "DataTable"
+    | "DataTableColumn"
     | "DatePicker"
     | "Input"
     | "Layout"
@@ -38,7 +40,20 @@ export interface Component {
     | "Select"
     | "Text"
     | "Textarea";
-  config: Button | Checkbox | Combobox | DatePicker | Input | Layout | Link | Radio | Select | Text | Textarea;
+  config:
+    | Button
+    | Checkbox
+    | Combobox
+    | DataTable
+    | DataTableColumn
+    | DatePicker
+    | Input
+    | Layout
+    | Link
+    | Radio
+    | Select
+    | Text
+    | Textarea;
 }
 export interface Button {
   action: string;
@@ -63,6 +78,19 @@ export interface Combobox {
   mdSpan: string;
   value: string;
   withDropdown: boolean;
+}
+export interface DataTable {
+  components: Component[];
+  label: string;
+  lgSpan: string;
+  mdSpan: string;
+  value: string;
+}
+export interface DataTableColumn {
+  header: string;
+  lgSpan: string;
+  mdSpan: string;
+  value: string;
 }
 export interface DatePicker {
   datePattern: string;


### PR DESCRIPTION
I implemented the first version of the DataTable component in the form editor. It can:
- Add new columns via quick actions of DataTable
- Move columns within DataTables
- Delete columns via delete or quick action of Column
- Show a button to define a list of objects when the DataTable value is empty (a warning appears if the value is empty)
- Generate columns based on the DataTable-value if something is defined (only show Button if DataTable-value is defined)
- Define column value via browser if a list of objects is set within the DataTable

Open To-Dos:
- Generation doesn’t work for lists of strings or primitive data types
- Column movement across different DataTables should be disabled
- Tests (UT/IT)

![firstOfDataTable](https://github.com/user-attachments/assets/a96780a8-f546-465d-a894-6feb3893be7a)
