### PR TITLE
XIVY-13646 Make Columns of DataTable typesave

### DIFF
--- a/packages/editor/src/components/blocks/datatablecolumn/DataTableColumn.tsx
+++ b/packages/editor/src/components/blocks/datatablecolumn/DataTableColumn.tsx
@@ -1,14 +1,13 @@
-import type { DataTableColumn, Prettify } from '@axonivy/form-editor-protocol';
+import type { DataTableColumnConfig, Prettify } from '@axonivy/form-editor-protocol';
 import type { ComponentConfig, UiComponentProps } from '../../../types/config';
-import { baseComponentFields, defaultBaseComponent } from '../base';
+import { baseComponentFields } from '../base';
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@axonivy/ui-components';
 
-type DataTableColumnProps = Prettify<DataTableColumn>;
+type DataTableColumnProps = Prettify<DataTableColumnConfig>;
 
-export const defaultDataTableColumnProps: DataTableColumn = {
+export const defaultDataTableColumnProps: DataTableColumnConfig = {
   header: 'header',
-  value: 'value',
-  ...defaultBaseComponent
+  value: 'value'
 } as const;
 
 export const DataTableColumnComponent: ComponentConfig<DataTableColumnProps> = {
@@ -38,7 +37,7 @@ const UiBlock = ({ header, value }: UiComponentProps<DataTableColumnProps>) => (
     </TableHeader>
     <TableBody>
       <TableRow>
-        <TableCell>{value}</TableCell>
+        <TableCell>{value.length === 0 ? 'Use entire Object' : value}</TableCell>
       </TableRow>
     </TableBody>
   </Table>

--- a/packages/editor/src/components/components.ts
+++ b/packages/editor/src/components/components.ts
@@ -7,7 +7,7 @@ import { LinkComponent } from './blocks/link/Link';
 import { TextComponent } from './blocks/text/Text';
 import { CheckboxComponent } from './blocks/checkbox/Checkbox';
 import { SelectComponent } from './blocks/select/Select';
-import type { ComponentType } from '@axonivy/form-editor-protocol';
+import type { ComponentData, ComponentType } from '@axonivy/form-editor-protocol';
 import type { AutoCompleteWithString } from '../types/types';
 import { ComboboxComponent } from './blocks/combobox/Combobox';
 import { RadioComponent } from './blocks/radio/Radio';
@@ -16,6 +16,7 @@ import { TextareaComponent } from './blocks/textarea/Textarea';
 import { DataTableComponent } from './blocks/datatable/DataTable';
 import { DataTableColumnComponent } from './blocks/datatablecolumn/DataTableColumn';
 import { FieldsetComponent } from './blocks/fieldset/Fieldset';
+import { findParentTableComponent } from '../data/data';
 
 const config: Config = {
   components: {
@@ -35,6 +36,14 @@ const config: Config = {
     Fieldset: FieldsetComponent
   }
 } as const;
+
+export const componentByElement = (element: ComponentData, data: Array<ComponentData>) => {
+  const component = componentByName(element.type);
+  if (component === undefined && findParentTableComponent(data, element)) {
+    return componentByName('DataTableColumn');
+  }
+  return component;
+};
 
 export const componentByName = (name: AutoCompleteWithString<ComponentType>) => {
   return config.components[name];

--- a/packages/editor/src/data/variable-tree-data.ts
+++ b/packages/editor/src/data/variable-tree-data.ts
@@ -126,7 +126,7 @@ export function findAttributesOfType(data: VariableInfo, variableName: string, m
           value: 'Use entire Object',
           info: extractedType,
           icon: IvyIcons.Attribute,
-          data: undefined,
+          data: { attribute: nameToSearch, description: '', simpleType: extractedType, type: extractedType },
           children,
           isLoaded: true
         }

--- a/packages/editor/src/editor/ItemDragOverlay.tsx
+++ b/packages/editor/src/editor/ItemDragOverlay.tsx
@@ -1,11 +1,11 @@
 import type { CreateComponentData } from '../types/config';
-import { componentByName } from '../components/components';
+import { componentByElement, componentByName } from '../components/components';
 import { ComponentBlockOverlay } from './canvas/ComponentBlock';
 import { PaletteItemOverlay } from './palette/PaletteItem';
 import { useData } from '../data/data';
 
 export const ItemDragOverlay = ({ activeId, createData }: { activeId?: string; createData?: CreateComponentData }) => {
-  const { element } = useData();
+  const { element, data } = useData();
   if (!activeId) {
     return null;
   }
@@ -14,7 +14,7 @@ export const ItemDragOverlay = ({ activeId, createData }: { activeId?: string; c
     return <PaletteItemOverlay {...component} data={createData} />;
   }
   if (element) {
-    const component = componentByName(element.type);
+    const component = componentByElement(element, data.components);
     return <ComponentBlockOverlay config={component} data={element} />;
   }
   return null;

--- a/packages/editor/src/editor/sidebar/Properties.tsx
+++ b/packages/editor/src/editor/sidebar/Properties.tsx
@@ -12,14 +12,15 @@ import {
 } from '@axonivy/ui-components';
 import { useData } from '../../data/data';
 import { groupFieldsBySubsection, visibleFields, visibleSections, type VisibleFields } from './property';
-import { componentByName } from '../../components/components';
+import { componentByElement } from '../../components/components';
+import type { ConfigData } from '@axonivy/form-editor-protocol';
 
 export const Properties = () => {
-  const { element, parent } = useData();
+  const { element, data, parent } = useData();
   if (element === undefined) {
     return <PanelMessage message='Select an Element to edit its properties.' />;
   }
-  const propertyConfig = componentByName(element.type);
+  const propertyConfig = componentByElement(element, data.components);
   const elementConfig = { ...propertyConfig.defaultProps, ...element.config };
   const fields = visibleFields(propertyConfig.fields, elementConfig);
   const sections = visibleSections(fields, parent);
@@ -62,7 +63,7 @@ const PropertySubSection = ({ title, fields }: { title: string; fields: VisibleF
               key={`${element.id}-${key}`}
               value={value}
               onChange={change => {
-                element.config[key] = change;
+                (element.config as ConfigData)[key] = change;
                 setElement(element);
               }}
               field={{ ...field, label: field.label ?? key }}

--- a/packages/editor/src/editor/sidebar/fields/browser/useAttributeBrowser.tsx
+++ b/packages/editor/src/editor/sidebar/fields/browser/useAttributeBrowser.tsx
@@ -3,7 +3,7 @@ import { IvyIcons } from '@axonivy/ui-icons';
 import { useMeta } from '../../../../context/useMeta';
 import { findAttributesOfType, fullVariablePath, variableTreeData, findVariablesOfType } from '../../../../data/variable-tree-data';
 import { useCallback, useEffect, useState } from 'react';
-import type { Variable } from '@axonivy/form-editor-protocol';
+import type { ConfigData, Variable } from '@axonivy/form-editor-protocol';
 import { useAppContext } from '../../../../context/AppContext';
 import { findParentTableComponent, useData } from '../../../../data/data';
 import type { OnlyAttributeSelection } from '../../../../types/config';
@@ -15,7 +15,7 @@ export const useAttributeBrowser = (onlyAttributesFor?: OnlyAttributeSelection, 
   const { context } = useAppContext();
   const variableInfo = useMeta('meta/data/attributes', context, { types: {}, variables: [] }).data;
   const { element, data } = useData();
-  const dynamicList = element?.config.dynamicItemsList as string;
+  const dynamicList = (element?.config as ConfigData).dynamicItemsList as string;
 
   useEffect(() => {
     if (onlyTypesOf && !onlyAttributesFor) {

--- a/packages/protocol/src/data/form-data.ts
+++ b/packages/protocol/src/data/form-data.ts
@@ -1,7 +1,7 @@
 import type { KeysOfUnion } from '../utils/type-helper';
-import type { Component, Fieldset, Form, Layout } from './form';
+import type { Component, DataTableColumn, Fieldset, Form, Layout } from './form';
 
-export type ComponentType = Component['type'];
+export type ComponentType = Component['type'] | 'DataTableColumn';
 
 export type ComponentConfigKeys = KeysOfUnion<Component['config']>;
 
@@ -9,9 +9,15 @@ export type PrimitiveValue = string | boolean | number | any[];
 
 export type ConfigData = Record<string, PrimitiveValue | Array<ComponentData>>;
 
-export type ComponentData = Omit<Component, 'config'> & {
-  config: ConfigData;
-};
+export interface DataTableColumnComponent extends DataTableColumn {
+  type: 'DataTableColumn';
+}
+
+export type ComponentData =
+  | (Omit<Component, 'config'> & {
+      config: ConfigData;
+    })
+  | DataTableColumnComponent;
 
 export type LayoutConfig = ComponentData & { config: Omit<Layout, 'components'> & { components: Array<ComponentData> } };
 
@@ -30,7 +36,7 @@ export const isTable = (component?: Component | ComponentData): component is Lay
 };
 
 export const isFreeLayout = (component?: Component | ComponentData): component is LayoutConfig => {
-  return isStructure(component) && component.config.gridVariant === 'FREE';
+  return isStructure(component) && (component as LayoutConfig).config.gridVariant === 'FREE';
 };
 
 export type FormContext = { app: string; pmv: string; file: string };

--- a/packages/protocol/src/data/form.ts
+++ b/packages/protocol/src/data/form.ts
@@ -41,21 +41,7 @@ export interface Component {
     | 'Text'
     | 'Textarea'
     | 'Fieldset';
-  config:
-    | Button
-    | Checkbox
-    | Combobox
-    | DataTable
-    | DataTableColumn
-    | DatePicker
-    | Input
-    | Layout
-    | Link
-    | Radio
-    | Select
-    | Text
-    | Textarea
-    | Fieldset;
+  config: Button | Checkbox | Combobox | DataTable | DatePicker | Input | Layout | Link | Radio | Select | Text | Textarea | Fieldset;
 }
 export interface Button {
   action: string;
@@ -82,16 +68,18 @@ export interface Combobox {
   withDropdown: boolean;
 }
 export interface DataTable {
-  components: Component[];
+  components: DataTableColumn[];
   label: string;
   lgSpan: string;
   mdSpan: string;
   value: string;
 }
 export interface DataTableColumn {
+  config: DataTableColumnConfig;
+  id: string;
+}
+export interface DataTableColumnConfig {
   header: string;
-  lgSpan: string;
-  mdSpan: string;
   value: string;
 }
 export interface DatePicker {


### PR DESCRIPTION
here is the implementation of the new schema from the backend. 
https://github.com/axonivy/core/pull/6748

In addition, I have added a feature that allows lists of primitive data types (string...) to be selected correctly.

![datatablelle](https://github.com/user-attachments/assets/21c6f2e7-f4c3-43c4-b582-06a65db415a5)
