### PR TITLE
XIVY-13646 Control height of all columns

### DIFF
--- a/packages/editor/src/components/blocks/datatable/DataTable.css
+++ b/packages/editor/src/components/blocks/datatable/DataTable.css
@@ -70,3 +70,16 @@
 .canvas[data-help-paddings='false'] .block-table .block-table__columns .draggable {
   border-radius: 0;
 }
+
+.block-table__columns:has(.block-search__input) .block-search__placeholder {
+  border: 1px solid var(--N25);
+  color: var(--N25);
+  padding: var(--size-2);
+  font-size: 0.7rem;
+  font-weight: normal;
+  user-select: none;
+}
+
+.block-table__columns:not(:has(.block-search__input)) .block-search__placeholder {
+  display: none;
+}

--- a/packages/editor/src/components/blocks/datatablecolumn/DataTableColumn.css
+++ b/packages/editor/src/components/blocks/datatablecolumn/DataTableColumn.css
@@ -8,4 +8,7 @@
   font-size: 0.7rem;
   font-weight: normal;
   border-radius: var(--border-r2);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }

--- a/packages/editor/src/components/blocks/datatablecolumn/DataTableColumn.tsx
+++ b/packages/editor/src/components/blocks/datatablecolumn/DataTableColumn.tsx
@@ -44,7 +44,11 @@ const UiBlock = ({ header, value, sortable, filterable }: UiComponentProps<DataT
               {header}
               {sortable && <IvyIcon icon={IvyIcons.Selector} />}
             </Flex>
-            {filterable && <span className='block-search__input'>Filter By {header}</span>}
+            {filterable ? (
+              <span className='block-search__input'>Filter By {header}</span>
+            ) : (
+              <span className='block-search__placeholder'>placeholder</span>
+            )}
           </Flex>
         </TableHead>
       </TableRow>

--- a/packages/editor/src/editor/canvas/ComponentBlock.tsx
+++ b/packages/editor/src/editor/canvas/ComponentBlock.tsx
@@ -53,6 +53,7 @@ const Draggable = ({ config, data }: DraggableProps) => {
   };
   const createElement = (name: string) =>
     setData(oldData => modifyData(oldData, { type: 'add', data: { componentName: name, targetId: data.id } }).newData);
+
   return (
     <Popover open={isSelected && !isDragging}>
       <PopoverAnchor asChild>


### PR DESCRIPTION
I tried to make it so that the height of the header in each column is adjusted simultaneously when a filter is set anywhere. This makes everything look and feel a bit nicer. 

I’m not sure if the way I’ve implemented it is good. What do you think? Maybe it’s overkill, but I wanted to give it a try. However, I’m happy to discard this and keep things as they were to avoid adding too much additional logic.

![Animation](https://github.com/user-attachments/assets/e3880ab4-b67c-474b-9937-b169f19d5494)
