### PR TITLE
XIVY-13646 Hold state of filter-/sortable of Column

### DIFF
--- a/packages/editor/src/components/blocks/datatablecolumn/DataTableColumn.tsx
+++ b/packages/editor/src/components/blocks/datatablecolumn/DataTableColumn.tsx
@@ -22,7 +22,7 @@ export const DataTableColumnComponent: ComponentConfig<DataTableColumnProps> = {
   description: 'A Column for the DataTable',
   defaultProps: defaultDataTableColumnProps,
   render: props => <UiBlock {...props} />,
-  create: ({ label, value }) => ({ ...defaultDataTableColumnProps, header: label, value }),
+  create: ({ label, value, defaultProps }) => ({ ...defaultDataTableColumnProps, header: label, value, ...defaultProps }),
   outlineInfo: component => component.header,
   fields: {
     header: { subsection: 'General', label: 'Header', type: 'text' },

--- a/packages/editor/src/editor/sidebar/fields/datatable-columns/ColumnsCheckboxField.tsx
+++ b/packages/editor/src/editor/sidebar/fields/datatable-columns/ColumnsCheckboxField.tsx
@@ -11,14 +11,16 @@ type ColumnsCheckboxFieldProps = {
 export type CheckboxColumn = DataTableColumn & { selected: boolean };
 
 export const ColumnsCheckboxField = ({ onChange }: ColumnsCheckboxFieldProps) => {
-  const { boundColumns, activeColumns, boundSelectColumns, unboundSelectColumns, setUnboundSelectColumns } = useDataTableColumns();
+  const { boundColumns, activeColumns, boundSelectColumns, unboundSelectColumns, setUnboundSelectColumns, setActiveColumnsHistory } =
+    useDataTableColumns();
 
   const handleCheckboxChange = (e: boolean | 'indeterminate', column: CheckboxColumn) => {
     if (e === true) {
       const newColumn: DataTableColumn = {
         config: DataTableColumnComponent.create({
           label: column.config.header,
-          value: column.config.value
+          value: column.config.value,
+          defaultProps: { filterable: column.config.filterable, sortable: column.config.sortable }
         }),
         id: createId('DataTableColumn')
       };
@@ -29,7 +31,7 @@ export const ColumnsCheckboxField = ({ onChange }: ColumnsCheckboxFieldProps) =>
         }
         return col;
       });
-
+      setActiveColumnsHistory(prevArray => [...prevArray, newColumn]);
       setUnboundSelectColumns(updatedLocalUnbindedColumns);
       onChange(newColumns);
     } else if (e === false) {

--- a/packages/editor/src/editor/sidebar/fields/datatable-columns/useDataTableColumns.ts
+++ b/packages/editor/src/editor/sidebar/fields/datatable-columns/useDataTableColumns.ts
@@ -20,8 +20,16 @@ export const useDataTableColumns = () => {
   );
   const activeColumns = element && element.id.startsWith('DataTable') ? (element.config as unknown as DataTable).components : [];
   const boundColumns = convertBrowserNodesToColumns(attributesOfTableType);
+
+  const [activeColumnsHistory, setActiveColumnsHistory] = useState<DataTableColumn[]>(activeColumns);
+
   const boundSelectColumns = boundColumns.map<CheckboxColumn>(column => ({
     ...column,
+    config: {
+      ...column.config,
+      filterable: activeColumnsHistory.find(col => isSameColumn(col, column))?.config.filterable ?? false,
+      sortable: activeColumnsHistory.find(col => isSameColumn(col, column))?.config.sortable ?? false
+    },
     selected: activeColumns ? activeColumns.some(col => isSameColumn(col, column)) : false
   }));
   // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -60,7 +68,8 @@ export const useDataTableColumns = () => {
     activeColumns,
     boundSelectColumns,
     unboundSelectColumns,
-    setUnboundSelectColumns
+    setUnboundSelectColumns,
+    setActiveColumnsHistory
   };
 };
 


### PR DESCRIPTION
Previously, when a column was shown/hidden using the checkbox and filterable/sortable options were defined, they were reset. With these changes this is no longer the case.