### PR TITLE
XIVY-13129 Fix CMS-Apply & add Browser to Label-Property

### DIFF
--- a/packages/editor/src/components/blocks/base.ts
+++ b/packages/editor/src/components/blocks/base.ts
@@ -31,7 +31,7 @@ export const baseComponentFields: Fields<BaseComponentProps> = {
 };
 
 export const selectItemsComponentFields: Fields<SelectItemsProps> = {
-  label: { subsection: 'General', label: 'Label', type: 'text' },
+  label: { subsection: 'General', label: 'Label', type: 'textBrowser', browsers: ['CMS'] },
   value: { subsection: 'General', label: 'Value', type: 'textBrowser', browsers: ['ATTRIBUTE'] },
   staticItems: { subsection: 'Static Options', label: 'Options', type: 'selectTable' },
   dynamicItemsList: {

--- a/packages/editor/src/components/blocks/button/Button.tsx
+++ b/packages/editor/src/components/blocks/button/Button.tsx
@@ -37,7 +37,7 @@ export const ButtonComponent: ComponentConfig<ButtonProps> = {
   create: ({ label, value, defaultProps }) => ({ ...defaultButtonProps, name: label, action: value, ...defaultProps }),
   outlineInfo: component => component.name,
   fields: {
-    name: { subsection: 'General', label: 'Name', type: 'text' },
+    name: { subsection: 'General', label: 'Name', type: 'textBrowser', browsers: ['CMS'] },
     action: { subsection: 'General', label: 'Action', type: 'textBrowser', browsers: ['LOGIC'] },
     variant: { subsection: 'General', label: 'Variant', type: 'select', options: variantOptions },
     icon: { subsection: 'General', label: 'Icon', type: 'select', options: iconOptions },

--- a/packages/editor/src/components/blocks/checkbox/Checkbox.tsx
+++ b/packages/editor/src/components/blocks/checkbox/Checkbox.tsx
@@ -24,7 +24,7 @@ export const CheckboxComponent: ComponentConfig<CheckboxProps> = {
   create: ({ label, value, ...defaultProps }) => ({ ...defaultCheckboxProps, label, selected: value, ...defaultProps }),
   outlineInfo: component => component.label,
   fields: {
-    label: { subsection: 'General', label: 'Label', type: 'text' },
+    label: { subsection: 'General', label: 'Label', type: 'textBrowser', browsers: ['CMS'] },
     selected: { subsection: 'General', label: 'Selected', type: 'textBrowser', browsers: ['ATTRIBUTE'] },
     ...baseComponentFields
   },

--- a/packages/editor/src/components/blocks/combobox/Combobox.tsx
+++ b/packages/editor/src/components/blocks/combobox/Combobox.tsx
@@ -29,7 +29,7 @@ export const ComboboxComponent: ComponentConfig<ComboboxProps> = {
   create: ({ label, value, ...defaultProps }) => ({ ...defaultInputProps, label, value, ...defaultProps }),
   outlineInfo: component => component.label,
   fields: {
-    label: { subsection: 'General', label: 'Label', type: 'text' },
+    label: { subsection: 'General', label: 'Label', type: 'textBrowser', browsers: ['CMS'] },
     value: { subsection: 'General', label: 'Value', type: 'textBrowser', browsers: ['ATTRIBUTE'] },
     completeMethod: { subsection: 'Options', label: 'Complete Method', type: 'textBrowser', browsers: ['LOGIC'] },
     itemLabel: {

--- a/packages/editor/src/components/blocks/composite/Composite.tsx
+++ b/packages/editor/src/components/blocks/composite/Composite.tsx
@@ -30,7 +30,7 @@ export const CompositeComponent: ComponentConfig<CompositeProps> = {
   create: ({ label, defaultProps }) => ({ ...defaultCompositeProps, name: label, ...defaultProps }),
   outlineInfo: component => component.name,
   fields: {
-    name: { subsection: 'General', label: 'Name', type: 'text' },
+    name: { subsection: 'General', label: 'Name', type: 'textBrowser', browsers: ['CMS'] },
     startMethod: { subsection: 'General', label: 'Start Method', type: 'generic', render: renderStartMethodSelect },
     parameters: { section: 'Parameters', subsection: 'General', label: 'Parameters', type: 'generic', render: renderParameters },
     ...baseComponentFields

--- a/packages/editor/src/components/blocks/datatablecolumn/DataTableColumn.tsx
+++ b/packages/editor/src/components/blocks/datatablecolumn/DataTableColumn.tsx
@@ -25,7 +25,7 @@ export const DataTableColumnComponent: ComponentConfig<DataTableColumnProps> = {
   create: ({ label, value, defaultProps }) => ({ ...defaultDataTableColumnProps, header: label, value, ...defaultProps }),
   outlineInfo: component => component.header,
   fields: {
-    header: { subsection: 'General', label: 'Header', type: 'text' },
+    header: { subsection: 'General', label: 'Header', type: 'textBrowser', browsers: ['CMS'] },
     value: { subsection: 'General', label: 'Value', type: 'textBrowser', browsers: ['ATTRIBUTE'], options: { onlyAttributes: 'COLUMN' } },
     sortable: { subsection: 'General', label: 'Enable Sorting', type: 'checkbox' },
     filterable: { subsection: 'General', label: 'Enable Filtering', type: 'checkbox' },

--- a/packages/editor/src/components/blocks/datepicker/DatePicker.tsx
+++ b/packages/editor/src/components/blocks/datepicker/DatePicker.tsx
@@ -26,7 +26,7 @@ export const DatePickerComponent: ComponentConfig<DatePickerProps> = {
   create: ({ label, value, ...defaultProps }) => ({ ...defaultInputProps, label, value, ...defaultProps }),
   outlineInfo: component => component.label,
   fields: {
-    label: { subsection: 'General', label: 'Label', type: 'text' },
+    label: { subsection: 'General', label: 'Label', type: 'textBrowser', browsers: ['CMS'] },
     value: { subsection: 'General', label: 'Value', type: 'textBrowser', browsers: ['ATTRIBUTE'], options: { onlyTypesOf: 'Date' } },
     datePattern: { subsection: 'General', label: 'Date Pattern', type: 'text', options: { placeholder: 'e.g. dd.MM.yyyy' } },
     showTime: { subsection: 'General', label: 'Show Time', type: 'checkbox' },

--- a/packages/editor/src/components/blocks/input/Input.tsx
+++ b/packages/editor/src/components/blocks/input/Input.tsx
@@ -32,7 +32,7 @@ export const InputComponent: ComponentConfig<InputProps> = {
   create: ({ label, value, ...defaultProps }) => ({ ...defaultInputProps, label, value, ...defaultProps }),
   outlineInfo: component => component.label,
   fields: {
-    label: { subsection: 'General', label: 'Label', type: 'text' },
+    label: { subsection: 'General', label: 'Label', type: 'textBrowser', browsers: ['CMS'] },
     required: { subsection: 'General', label: 'Required', type: 'checkbox' },
     value: { subsection: 'General', label: 'Value', type: 'textBrowser', browsers: ['ATTRIBUTE'] },
     type: { subsection: 'General', label: 'Type', type: 'select', options: typeOptions },

--- a/packages/editor/src/components/blocks/link/Link.tsx
+++ b/packages/editor/src/components/blocks/link/Link.tsx
@@ -23,7 +23,7 @@ export const LinkComponent: ComponentConfig<LinkProps> = {
   create: () => defaultLinkProps,
   outlineInfo: component => component.name,
   fields: {
-    name: { subsection: 'General', label: 'Name', type: 'text' },
+    name: { subsection: 'General', label: 'Name', type: 'textBrowser', browsers: ['CMS'] },
     href: { subsection: 'General', label: 'Href', type: 'text' },
     ...baseComponentFields
   },

--- a/packages/editor/src/components/blocks/textarea/Textarea.tsx
+++ b/packages/editor/src/components/blocks/textarea/Textarea.tsx
@@ -25,7 +25,7 @@ export const TextareaComponent: ComponentConfig<TextareaProps> = {
   create: ({ label, value, ...defaultProps }) => ({ ...defaultInputProps, label, value, ...defaultProps }),
   outlineInfo: component => component.label,
   fields: {
-    label: { subsection: 'General', label: 'Label', type: 'text' },
+    label: { subsection: 'General', label: 'Label', type: 'textBrowser', browsers: ['CMS'] },
     value: { subsection: 'General', label: 'Value', type: 'textBrowser', browsers: ['ATTRIBUTE'] },
     rows: { subsection: 'General', label: 'Visible Rows', type: 'number' },
     autoResize: { subsection: 'General', label: 'Auto Resize', type: 'checkbox' },

--- a/packages/editor/src/editor/sidebar/fields/InputFieldWithBrowser.tsx
+++ b/packages/editor/src/editor/sidebar/fields/InputFieldWithBrowser.tsx
@@ -39,7 +39,10 @@ export const InputFieldWithBrowser = ({
           </DialogTrigger>
         </InputGroup>
       </BasicField>
-      <DialogContent style={{ height: '80vh' }} onCloseAutoFocus={e => focusBracketContent(e, value, inputRef.current)}>
+      <DialogContent
+        style={{ height: '80vh' }}
+        onCloseAutoFocus={activeBrowsers.includes(logicBrowser) ? e => focusBracketContent(e, value, inputRef.current) : undefined}
+      >
         <BrowsersView
           browsers={activeBrowsers}
           apply={(browserName, result) => {

--- a/packages/editor/src/editor/sidebar/fields/browser/useCmsBrowser.tsx
+++ b/packages/editor/src/editor/sidebar/fields/browser/useCmsBrowser.tsx
@@ -33,7 +33,7 @@ export const useCmsBrowser = (): Browser => {
     ),
 
     infoProvider: row => <CmsInfoProvider row={row} />,
-    applyModifier: row => ({ value: 'ivy.cms.co("' + (row.original.data as ContentObject).fullPath + '")' })
+    applyModifier: row => ({ value: `ivy.cms.co('${(row.original.data as ContentObject).fullPath}')` })
   };
 };
 

--- a/packages/editor/src/editor/sidebar/fields/table-field/InputCellWithBrowser.tsx
+++ b/packages/editor/src/editor/sidebar/fields/table-field/InputCellWithBrowser.tsx
@@ -10,5 +10,5 @@ type InputCellProps<TData> = InputProps & {
 export const InputCellWithBrowser = <TData,>({ cell }: InputCellProps<TData>) => {
   const { value, setValue, onBlur } = useEditCell(cell);
 
-  return <InputFieldWithBrowser label='' onChange={setValue} value={value} onBlur={onBlur} browsers={['ATTRIBUTE']} />;
+  return <InputFieldWithBrowser label='' onChange={setValue} value={value} onBlur={onBlur} browsers={['ATTRIBUTE', 'CMS']} />;
 };


### PR DESCRIPTION
- Improved apply to use '/bla' instead of "/bla" so that the CMS-EL-Expression causes no error during rendering. Final CMS-apply looks like this: #{ivy.cms.co('/bla')}
- Added the CMS-Browser to all Label and Name Properties