### PR TITLE
Add condition builder

### DIFF
--- a/packages/editor/src/components/blocks/base.ts
+++ b/packages/editor/src/components/blocks/base.ts
@@ -50,17 +50,17 @@ export const baseComponentFields: Fields<BaseComponentProps> = {
 };
 
 export const visibleComponentField: Fields<VisibleItemProps> = {
-  visible: { subsection: 'Behaviour', label: 'Visible', type: 'textBrowser', browsers: ['ATTRIBUTE'] }
+  visible: { subsection: 'Behaviour', label: 'Visible', type: 'textConditionBuilder' }
 };
 
 export const disabledComponentFields: Fields<DisabledItemProps> = {
   ...visibleComponentField,
-  disabled: { subsection: 'Behaviour', label: 'Disable', type: 'textBrowser', browsers: ['ATTRIBUTE'] }
+  disabled: { subsection: 'Behaviour', label: 'Disable', type: 'textConditionBuilder' }
 };
 
 export const behaviourComponentFields: Fields<BehaviourItemProps> = {
   ...disabledComponentFields,
-  required: { subsection: 'Behaviour', label: 'Required', type: 'textBrowser', browsers: ['ATTRIBUTE'] },
+  required: { subsection: 'Behaviour', label: 'Required', type: 'textConditionBuilder' },
   requiredMessage: {
     subsection: 'Behaviour',
     label: 'Required Message',

--- a/packages/editor/src/editor/sidebar/PropertyItem.tsx
+++ b/packages/editor/src/editor/sidebar/PropertyItem.tsx
@@ -9,6 +9,7 @@ import { InputField } from './fields/InputField';
 import { InputFieldWithBrowser } from './fields/InputFieldWithBrowser';
 import { SelectTableField } from './fields/table-field/SelectTableField';
 import { ColumnsCheckboxField } from './fields/datatable-columns/ColumnsCheckboxField';
+import { InputFieldWithConditionBuilder } from './fields/condition-builder/InputFieldWithConditionBuilder';
 
 type PropertyItemProps = {
   value: PrimitiveValue;
@@ -42,6 +43,8 @@ export const PropertyItem = ({ value: initValue, onChange, field }: PropertyItem
             options={field.options}
           />
         );
+      case 'textConditionBuilder':
+        return <InputFieldWithConditionBuilder label={label} value={toString(value)} onChange={updateValue} />;
       case 'selectTable':
         return <SelectTableField label={label} data={toSelectItems(value)} onChange={updateValue} />;
       case 'selectColums':

--- a/packages/editor/src/editor/sidebar/fields/InputField.tsx
+++ b/packages/editor/src/editor/sidebar/fields/InputField.tsx
@@ -2,7 +2,7 @@ import { BasicField, Input, type MessageData } from '@axonivy/ui-components';
 import type { TextFieldOptions } from '../../../types/config';
 
 export type InputFieldProps = {
-  label: string;
+  label?: string;
   value: string;
   onChange: (value: string) => void;
   onBlur?: () => void;

--- a/packages/editor/src/editor/sidebar/fields/InputFieldWithBrowser.tsx
+++ b/packages/editor/src/editor/sidebar/fields/InputFieldWithBrowser.tsx
@@ -31,7 +31,7 @@ export const InputFieldWithBrowser = ({
 
   return (
     <Dialog open={open} onOpenChange={setOpen}>
-      <BasicField label={label} message={message}>
+      <BasicField label={label} message={message} style={{ flex: '1' }}>
         <InputGroup>
           <Input ref={inputRef} value={value} onChange={e => onChange(e.target.value)} onBlur={onBlur} placeholder={options?.placeholder} />
           <DialogTrigger asChild>
@@ -49,7 +49,7 @@ export const InputFieldWithBrowser = ({
             if (result && browserName === CMS_BROWSER_ID) {
               onChange(`${value}#{${result.value}}`);
             } else if (result) {
-              onChange(options?.onlyAttributes ? `${result.value}` : `#{${result.value}}`);
+              onChange(options?.onlyAttributes || options?.directApply ? `${result.value}` : `#{${result.value}}`);
             }
             setOpen(false);
           }}

--- a/packages/editor/src/editor/sidebar/fields/SelectField.tsx
+++ b/packages/editor/src/editor/sidebar/fields/SelectField.tsx
@@ -3,18 +3,19 @@ import type { FieldOption } from '../../../types/config';
 
 type SelectFieldProps = {
   options: readonly FieldOption[];
-  label: string;
+  label?: string;
   value: string;
   onChange: (value: string) => void;
+  width?: string;
 };
 
-export const SelectField = ({ options, label, value, onChange }: SelectFieldProps) => (
+export const SelectField = ({ options, label, value, onChange, width }: SelectFieldProps) => (
   <BasicField label={label}>
     <Select value={value} onValueChange={change => onChange(change)}>
-      <SelectTrigger>
+      <SelectTrigger style={{ whiteSpace: 'nowrap' }}>
         <SelectValue placeholder='Select an option' />
       </SelectTrigger>
-      <SelectContent>
+      <SelectContent style={{ width: width }}>
         {options.map(option => (
           <SelectItem key={`${option.value}`} value={option.value as string}>
             {option.label}

--- a/packages/editor/src/editor/sidebar/fields/condition-builder/Condition.tsx
+++ b/packages/editor/src/editor/sidebar/fields/condition-builder/Condition.tsx
@@ -1,0 +1,102 @@
+import { Button, Flex, Label } from '@axonivy/ui-components';
+import { IvyIcons } from '@axonivy/ui-icons';
+import { InputFieldWithBrowser } from '../InputFieldWithBrowser';
+import { SelectField } from '../SelectField';
+import type { ConditionGroup } from './ConditionGroup';
+
+const typeOptions = [
+  { label: 'equal to', value: '==' },
+  { label: 'not equal to', value: '!=' },
+  { label: 'less than', value: '<' },
+  { label: 'greater than', value: '>' },
+  { label: 'less or equal to', value: '<=' },
+  { label: 'greater or equal to', value: '>=' },
+  { label: 'is true', value: 'isTrue' }
+] as const;
+type ConditionType = (typeof typeOptions)[number]['value'];
+
+export const logicalOperatorOptions = [
+  { label: 'and', value: 'and' },
+  { label: 'or', value: 'or' }
+] as const;
+export type LogicalOperator = (typeof logicalOperatorOptions)[number]['value'];
+
+export interface Condition {
+  argument1: string;
+  operator: ConditionType;
+  argument2: string;
+  logicalOperator: LogicalOperator;
+}
+
+export interface ConditionProps {
+  condition: Condition;
+  conditionIndex: number;
+  groupIndex: number;
+  conditionsCount: number;
+  setConditionGroups: React.Dispatch<React.SetStateAction<ConditionGroup[]>>;
+}
+
+export const Condition = ({ condition, conditionIndex, groupIndex, conditionsCount, setConditionGroups }: ConditionProps) => {
+  const updateCondition = <TKey extends keyof Condition>(
+    groupIndex: number,
+    conditionIndex: number,
+    key: TKey,
+    newValue: Condition[TKey]
+  ) => {
+    setConditionGroups(old => {
+      const newGroups = [...old];
+      newGroups[groupIndex].conditions[conditionIndex] = {
+        ...newGroups[groupIndex].conditions[conditionIndex],
+        [key]: newValue
+      };
+      return newGroups;
+    });
+  };
+
+  const removeCondition = (groupIndex: number, conditionIndex: number) => {
+    setConditionGroups(old => {
+      const newGroups = [...old];
+      newGroups[groupIndex].conditions.splice(conditionIndex, 1);
+      return newGroups;
+    });
+  };
+
+  return (
+    <Flex direction='column' style={{ border: 'var(--basic-border', borderRadius: 'var(--border-r2)', padding: 'var(--size-2)' }}>
+      <Flex direction='row' justifyContent='space-between'>
+        <Label>{`Condition ${conditionIndex + 1}`}</Label>
+        <Button onClick={() => removeCondition(groupIndex, conditionIndex)} icon={IvyIcons.Trash} aria-label='Remove Condition' />
+      </Flex>
+      <Flex alignItems='center' gap={2} direction='row'>
+        <InputFieldWithBrowser
+          value={condition.argument1}
+          onChange={val => updateCondition(groupIndex, conditionIndex, 'argument1', val)}
+          browsers={['ATTRIBUTE']}
+          options={{ directApply: true }}
+        />
+        <SelectField
+          options={typeOptions}
+          value={condition.operator}
+          onChange={val => updateCondition(groupIndex, conditionIndex, 'operator', val as ConditionType)}
+          width='150px'
+        />
+        {condition.operator !== 'isTrue' && (
+          <InputFieldWithBrowser
+            value={condition.argument2}
+            onChange={val => updateCondition(groupIndex, conditionIndex, 'argument2', val)}
+            browsers={['ATTRIBUTE']}
+            options={{ directApply: true }}
+          />
+        )}
+        {conditionIndex < conditionsCount - 1 && (
+          <SelectField
+            options={logicalOperatorOptions}
+            value={condition.logicalOperator}
+            onChange={val => updateCondition(groupIndex, conditionIndex, 'logicalOperator', val as LogicalOperator)}
+            width='70px'
+          />
+        )}
+      </Flex>
+    </Flex>
+  );
+};

--- a/packages/editor/src/editor/sidebar/fields/condition-builder/ConditionBuilder.tsx
+++ b/packages/editor/src/editor/sidebar/fields/condition-builder/ConditionBuilder.tsx
@@ -1,0 +1,102 @@
+import { BasicCheckbox, BasicCollapsible, Button, Flex, IvyIcon, Tabs, TabsList, TabsTrigger } from '@axonivy/ui-components';
+import { IvyIcons } from '@axonivy/ui-icons';
+import { useState } from 'react';
+import { ConditionGroup } from './ConditionGroup';
+
+interface ConditionBuilderProps {
+  onChange: (value: string) => void;
+  apply: () => void;
+}
+
+export const ConditionBuilder = ({ onChange, apply }: ConditionBuilderProps) => {
+  const [isConditionGroupEnabled, setIsConditionGroupEnabled] = useState(false);
+  const [conditionGroups, setConditionGroups] = useState<ConditionGroup[]>([
+    { conditions: [{ argument1: '', operator: '==', argument2: '', logicalOperator: 'and' }], logicalOperator: 'and' }
+  ]);
+
+  const addConditionGroup = () => {
+    setConditionGroups([
+      ...conditionGroups,
+      { conditions: [{ argument1: '', operator: '==', argument2: '', logicalOperator: 'and' }], logicalOperator: 'and' }
+    ]);
+  };
+
+  const generateConditionString = () => {
+    const wrapInQuotesIfNeeded = (arg: string) => {
+      return arg.startsWith('data.') || arg === 'data' ? arg : `'${arg}'`;
+    };
+
+    const groupStrings = conditionGroups.map((group, index) => {
+      const conditions = group.conditions
+        .map((con, index) => {
+          const formattedArg1 = wrapInQuotesIfNeeded(con.argument1);
+          const formattedArg2 = wrapInQuotesIfNeeded(con.argument2);
+          const condition = `${formattedArg1} ${con.operator} ${formattedArg2}`;
+          const logicalOp = index < group.conditions.length - 1 ? ` ${con.logicalOperator.toLowerCase()} ` : '';
+          return con.operator === 'isTrue' ? formattedArg1 : condition + logicalOp;
+        })
+        .join('');
+      const logicGroupOp = index < conditionGroups.length - 1 ? ` ${group.logicalOperator.toLowerCase()} ` : '';
+      return logicGroupOp === '' ? (conditionGroups.length === 1 ? conditions : `(${conditions})`) : `(${conditions}) ${logicGroupOp} `;
+    });
+
+    return `#{${groupStrings.join('')}}`;
+  };
+
+  const handleAddCondition = () => {
+    const finalCondition = generateConditionString();
+    onChange(finalCondition);
+    apply();
+  };
+
+  return (
+    <Tabs value='Condition' style={{ height: '100%', overflow: 'auto' }}>
+      <Flex direction='column' gap={1} style={{ height: '100%' }}>
+        <TabsList>
+          <TabsTrigger value='Condition'>
+            <IvyIcon icon={IvyIcons.Attribute} />
+            Condition
+          </TabsTrigger>
+        </TabsList>
+        <Flex direction='column' gap={1} justifyContent='space-between' style={{ height: '100%', overflow: 'auto' }}>
+          <Flex direction='column' gap={2}>
+            <BasicCheckbox
+              label='Enable Grouping'
+              checked={isConditionGroupEnabled}
+              onCheckedChange={() => setIsConditionGroupEnabled(!isConditionGroupEnabled)}
+              disabled={conditionGroups.length > 1 && isConditionGroupEnabled}
+            />
+            {conditionGroups.map((group, groupIndex) => (
+              <ConditionGroup
+                key={groupIndex}
+                group={group}
+                groupIndex={groupIndex}
+                groupCount={conditionGroups.length}
+                isConditionGroupEnabled={isConditionGroupEnabled}
+                setConditionGroups={setConditionGroups}
+              />
+            ))}
+            {(isConditionGroupEnabled || conditionGroups.length === 0) && (
+              <Button onClick={addConditionGroup} icon={IvyIcons.Plus} aria-label='Add Condition Group' variant='outline'>
+                {conditionGroups.length === 0 && !isConditionGroupEnabled ? 'Add Condition' : 'Add Condition Group'}
+              </Button>
+            )}
+          </Flex>
+          <Flex direction='column' gap={3}>
+            <BasicCollapsible label='Info' style={{ maxHeight: 50 }}>
+              {generateConditionString() || 'No condition defined yet'}
+            </BasicCollapsible>
+            <Flex justifyContent='flex-end' gap={2}>
+              <Button onClick={() => apply()} aria-label='Cancel' size='large'>
+                Cancel
+              </Button>
+              <Button onClick={handleAddCondition} aria-label='Apply Condition' size='large' variant='primary'>
+                Apply
+              </Button>
+            </Flex>
+          </Flex>
+        </Flex>
+      </Flex>
+    </Tabs>
+  );
+};

--- a/packages/editor/src/editor/sidebar/fields/condition-builder/ConditionGroup.tsx
+++ b/packages/editor/src/editor/sidebar/fields/condition-builder/ConditionGroup.tsx
@@ -1,0 +1,80 @@
+import { Button, Flex, Label } from '@axonivy/ui-components';
+import { IvyIcons } from '@axonivy/ui-icons';
+import { Condition, logicalOperatorOptions, type ConditionProps, type LogicalOperator } from './Condition';
+import { SelectField } from '../SelectField';
+
+export interface ConditionGroup {
+  conditions: Condition[];
+  logicalOperator: LogicalOperator;
+}
+
+interface ConditionGroupProps extends Pick<ConditionProps, 'setConditionGroups' | 'groupIndex'> {
+  group: ConditionGroup;
+  groupCount: number;
+  isConditionGroupEnabled: boolean;
+}
+
+export const ConditionGroup = ({ group, groupIndex, groupCount, isConditionGroupEnabled, setConditionGroups }: ConditionGroupProps) => {
+  const updateLogicalOperator = (index: number, newValue: LogicalOperator) => {
+    setConditionGroups(old => {
+      const newGroups = [...old];
+      newGroups[index].logicalOperator = newValue;
+      return newGroups;
+    });
+  };
+
+  const addCondition = (groupIndex: number) => {
+    setConditionGroups(old => {
+      const newGroups = [...old];
+      newGroups[groupIndex].conditions.push({ argument1: '', operator: '==', argument2: '', logicalOperator: 'and' });
+      return newGroups;
+    });
+  };
+
+  const removeConditionGroup = (groupIndex: number) => {
+    setConditionGroups(old => {
+      const newGroups = [...old];
+      newGroups.splice(groupIndex, 1);
+      return newGroups;
+    });
+  };
+
+  return (
+    <Flex direction='column' gap={2}>
+      <Flex
+        direction='column'
+        style={
+          isConditionGroupEnabled ? { border: 'var(--basic-border', borderRadius: 'var(--border-r2)', padding: 'var(--size-2)' } : undefined
+        }
+        gap={2}
+      >
+        {isConditionGroupEnabled && (
+          <Flex direction='row' justifyContent='space-between'>
+            <Label>{`Group ${groupIndex + 1}`}</Label>
+            <Button onClick={() => removeConditionGroup(groupIndex)} icon={IvyIcons.Trash} aria-label='Remove Group' />
+          </Flex>
+        )}
+        {group.conditions.map((condition, conditionIndex) => (
+          <Condition
+            key={conditionIndex}
+            condition={condition}
+            conditionIndex={conditionIndex}
+            groupIndex={groupIndex}
+            conditionsCount={group.conditions.length}
+            setConditionGroups={setConditionGroups}
+          />
+        ))}
+        <Button onClick={() => addCondition(groupIndex)} icon={IvyIcons.Plus} aria-label='Add Condition' variant='outline'>
+          Add Condition
+        </Button>
+      </Flex>
+      {groupIndex < groupCount - 1 && (
+        <SelectField
+          options={logicalOperatorOptions}
+          value={group.logicalOperator}
+          onChange={val => updateLogicalOperator(groupIndex, val as LogicalOperator)}
+        />
+      )}
+    </Flex>
+  );
+};

--- a/packages/editor/src/editor/sidebar/fields/condition-builder/InputFieldWithConditionBuilder.tsx
+++ b/packages/editor/src/editor/sidebar/fields/condition-builder/InputFieldWithConditionBuilder.tsx
@@ -1,0 +1,33 @@
+import { BasicField, Button, Dialog, DialogContent, DialogTrigger, Input, InputGroup } from '@axonivy/ui-components';
+import { IvyIcons } from '@axonivy/ui-icons';
+import { useState } from 'react';
+import type { InputFieldProps } from '../InputField';
+import type { TextBrowserFieldOptions } from '../../../../types/config';
+import { ConditionBuilder } from './ConditionBuilder';
+
+export const InputFieldWithConditionBuilder = ({
+  label,
+  value,
+  onChange,
+  onBlur,
+  message,
+  options
+}: InputFieldProps & { options?: TextBrowserFieldOptions }) => {
+  const [open, setOpen] = useState(false);
+
+  return (
+    <Dialog open={open} onOpenChange={setOpen}>
+      <BasicField label={label} message={message}>
+        <InputGroup>
+          <Input value={value} onChange={e => onChange(e.target.value)} onBlur={onBlur} placeholder={options?.placeholder} />
+          <DialogTrigger asChild title='Open Condition-Builder'>
+            <Button icon={IvyIcons.Process} aria-label='Browser' />
+          </DialogTrigger>
+        </InputGroup>
+      </BasicField>
+      <DialogContent style={{ height: '80vh', maxWidth: '600px' }}>
+        <ConditionBuilder onChange={onChange} apply={() => setOpen(false)} />
+      </DialogContent>
+    </Dialog>
+  );
+};

--- a/packages/editor/src/types/config.ts
+++ b/packages/editor/src/types/config.ts
@@ -40,10 +40,11 @@ export type Browser = 'ATTRIBUTE' | 'LOGIC' | 'CMS';
 export type TextBrowserFieldOptions = TextFieldOptions & {
   onlyTypesOf?: string;
   onlyAttributes?: OnlyAttributeSelection;
+  directApply?: boolean;
 };
 
 export type TextField<ComponentProps extends DefaultComponentProps = DefaultComponentProps> = BaseField<ComponentProps> & {
-  type: 'text' | 'number' | 'textarea' | 'checkbox';
+  type: 'text' | 'number' | 'textarea' | 'checkbox' | 'textConditionBuilder';
   options?: TextFieldOptions;
 };
 


### PR DESCRIPTION
Here is a first version of the Condition Builder. It can do the following:
- Build normal conditions with two arguments and an operator
- Link multiple conditions together using "and" or "or"
- Group multiple conditions and link these groups using "and/or"
- Pass a single argument and mark it as true

The last feature emerged from a conversation with Bruno, making it unnecessary for him to provide the attribute browser, as the same result can be achieved through the first condition and than the operator "is true".
![conditionBuilderPrototyp2](https://github.com/user-attachments/assets/a897b49a-9958-49b7-8447-7e1c7c31c3e3)
