### PR TITLE
XIVY-15076 Improve Panel & Fieldset behaviour if defaultCollapsed

### DIFF
--- a/packages/editor/src/components/blocks/fieldset/Fieldset.css
+++ b/packages/editor/src/components/blocks/fieldset/Fieldset.css
@@ -9,12 +9,11 @@ fieldset {
 }
 
 fieldset.collapsible {
-  cursor: pointer;
+  cursor: default;
 }
 
-fieldset.collapsible > legend:before {
-  content: '-';
-  padding: 0 5px 0 0;
+.canvas[data-help-paddings='false'] fieldset.collapsible.default-collapsed .drop-zone {
+  display: none;
 }
 
 legend {

--- a/packages/editor/src/components/blocks/fieldset/Fieldset.tsx
+++ b/packages/editor/src/components/blocks/fieldset/Fieldset.tsx
@@ -34,17 +34,20 @@ export const FieldsetComponent: ComponentConfig<FieldsetProps> = {
     components: { subsection: 'General', type: 'hidden' },
     legend: { subsection: 'General', label: 'Title', type: 'textBrowser', browsers: ['ATTRIBUTE', 'CMS'] },
     collapsible: { subsection: 'Behaviour', label: 'Collapsible', type: 'checkbox' },
-    collapsed: { subsection: 'Behaviour', label: 'Default collapsed', type: 'checkbox' },
+    collapsed: { subsection: 'Behaviour', label: 'Collapsed by default', type: 'checkbox', hide: data => !data.collapsible },
     ...visibleComponentField,
     ...baseComponentFields
   }
 };
 
-const UiBlock = ({ id, components, legend, collapsible, visible }: UiComponentProps<FieldsetProps>) => (
+const UiBlock = ({ id, components, legend, collapsible, collapsed, visible }: UiComponentProps<FieldsetProps>) => (
   <>
     <UiBlockHeader visible={visible} />
-    <fieldset className={`${collapsible ? 'collapsible' : ''}`}>
-      <legend>{legend}</legend>
+    <fieldset className={`${collapsible ? (collapsed ? 'collapsible default-collapsed' : 'collapsible') : ''}`}>
+      <legend>
+        {collapsible ? (collapsed ? '+ ' : '- ') : ''}
+        {legend}
+      </legend>
       {components.map((component, index) => (
         <ComponentBlock key={component.id} component={component} preId={components[index - 1]?.id} />
       ))}

--- a/packages/editor/src/components/blocks/panel/Panel.css
+++ b/packages/editor/src/components/blocks/panel/Panel.css
@@ -9,7 +9,7 @@
 }
 
 .i-panel-header {
-  cursor: pointer;
+  cursor: default;
   display: flex;
   flex-direction: row;
   justify-content: space-between;
@@ -17,6 +17,6 @@
   border-radius: 4px;
 }
 
-.i-panel-non-collapsible {
-  visibility: collapse;
+.canvas[data-help-paddings='false'] .i-panel.default-collapsed .drop-zone {
+  display: none;
 }

--- a/packages/editor/src/components/blocks/panel/Panel.tsx
+++ b/packages/editor/src/components/blocks/panel/Panel.tsx
@@ -36,19 +36,27 @@ export const PanelComponent: ComponentConfig<PanelProps> = {
     components: { subsection: 'General', type: 'hidden' },
     title: { subsection: 'General', label: 'Title', type: 'textBrowser', browsers: ['ATTRIBUTE', 'CMS'] },
     collapsible: { subsection: 'Behaviour', label: 'Collapsible', type: 'checkbox' },
-    collapsed: { subsection: 'Behaviour', label: 'Default collapsed', type: 'checkbox' },
+    collapsed: { subsection: 'Behaviour', label: 'Collapsed by default', type: 'checkbox', options: {}, hide: data => !data.collapsible },
     ...visibleComponentField,
     ...baseComponentFields
   }
 };
 
-const UiBlock = ({ id, components, title, collapsible, visible }: UiComponentProps<PanelProps>) => (
-  <div className='i-panel'>
+const UiBlock = ({ id, components, title, collapsible, collapsed, visible }: UiComponentProps<PanelProps>) => (
+  <div className={`i-panel ${collapsible && collapsed ? 'default-collapsed' : ''}`}>
     <div className='i-panel-header'>
       {title}
       <Flex gap={1} alignItems='center'>
         <UiBlockHeaderVisiblePart visible={visible} />
-        <IvyIcon icon={IvyIcons.Plus} className={`${collapsible ? '' : 'i-panel-non-collapsible'}`} />
+        {collapsible ? (
+          collapsed ? (
+            <IvyIcon icon={IvyIcons.Plus} className={`${collapsible ? '' : 'i-panel-non-collapsible'}`} />
+          ) : (
+            <svg width='12' height='1.3' viewBox='0 0 13 2' fill='none' xmlns='http://www.w3.org/2000/svg'>
+              <path d='M1 1L12 1' stroke='#4a4a4a' strokeWidth='1.13' strokeLinecap='round' />
+            </svg>
+          )
+        ) : null}
       </Flex>
     </div>
     {components.map((component, index) => (


### PR DESCRIPTION
Improved the Fieldset and Panel Component:
- Renamed Checkbox: "Default Collapsed" to "Collaped by default"
- Only show "Collapsed by default" if Collapsible was selected
- Show Minus if "Collapsed by default" is NOT selected and show + if it is
- If "Collapsed by default" is selected don't show content of Fieldset or Panel in Preview-Mode
- 
![fieldset_panel](https://github.com/user-attachments/assets/f3380f70-c24e-4f6d-ab49-09a48680f2c3)
