### PR TITLE
XIVY-14893 Add Create from Data to Quickbar & add comp. inside Structure

### DIFF
--- a/packages/editor/src/data/data.ts
+++ b/packages/editor/src/data/data.ts
@@ -200,14 +200,23 @@ export const createInitiTableColumns = (id: string, data: FormData, creates: Arr
   return data;
 };
 
-export const createInitForm = (data: FormData, creates: Array<CreateComponentData>, workflowButtons: boolean) => {
+export const createInitForm = (
+  data: FormData,
+  creates: Array<CreateComponentData>,
+  workflowButtons: boolean,
+  selectedElementId?: string
+) => {
   creates.forEach(create => {
-    data = modifyData(data, { type: 'add', data: { componentName: create.componentName, create } }).newData;
+    data = modifyData(data, { type: 'add', data: { componentName: create.componentName, create, targetId: selectedElementId } }).newData;
   });
   if (workflowButtons) {
     const { newData, newComponentId } = modifyData(data, {
       type: 'add',
-      data: { componentName: 'Layout', create: { label: '', value: '', defaultProps: { type: 'FLEX', justifyContent: 'END' } } }
+      data: {
+        componentName: 'Layout',
+        create: { label: '', value: '', defaultProps: { type: 'FLEX', justifyContent: 'END' } },
+        targetId: selectedElementId
+      }
     });
     const layoutId = `${STRUCTURE_DROPZONE_ID_PREFIX}${newComponentId}`;
     data = modifyData(newData, {

--- a/packages/editor/src/editor/canvas/ComponentBlock.tsx
+++ b/packages/editor/src/editor/canvas/ComponentBlock.tsx
@@ -12,6 +12,7 @@ import { Palette } from '../palette/Palette';
 import { allComponentsByCategory, componentByName } from '../../components/components';
 import { DropZone, type DropZoneProps } from './DropZone';
 import { useValidations } from '../../context/useValidation';
+import { DataClassDialog, getSelectedElementId } from './data-class/DataClassDialog';
 
 type ComponentBlockProps = Omit<DropZoneProps, 'id'> & {
   component: ComponentData | Component;
@@ -53,7 +54,9 @@ const Draggable = ({ config, data }: DraggableProps) => {
     );
   };
   const createElement = (name: string) =>
-    setData(oldData => modifyData(oldData, { type: 'add', data: { componentName: name, targetId: data.id } }).newData);
+    setData(
+      oldData => modifyData(oldData, { type: 'add', data: { componentName: name, targetId: getSelectedElementId(data.id) } }).newData
+    );
   const validations = useValidations(data.id);
   return (
     <Popover open={isSelected && !isDragging}>
@@ -99,6 +102,7 @@ const Draggable = ({ config, data }: DraggableProps) => {
         deleteAction={config.quickActions.includes('DELETE') ? deleteElement : undefined}
         duplicateAction={config.quickActions.includes('DUPLICATE') ? duplicateElement : undefined}
         createAction={config.quickActions.includes('CREATE') ? createElement : undefined}
+        createFromDataAction={config.quickActions.includes('CREATEFROMDATA') ? data.id : undefined}
         createColumnAction={config.quickActions.includes('CREATECOLUMN') ? createColumn : undefined}
       />
     </Popover>
@@ -115,9 +119,10 @@ type QuickbarProps = {
   duplicateAction?: () => void;
   createAction?: (name: string) => void;
   createColumnAction?: () => void;
+  createFromDataAction?: string;
 };
 
-const Quickbar = ({ deleteAction, duplicateAction, createAction, createColumnAction }: QuickbarProps) => {
+const Quickbar = ({ deleteAction, duplicateAction, createAction, createColumnAction, createFromDataAction }: QuickbarProps) => {
   const [menu, setMenu] = useState(false);
   return (
     <PopoverContent className='quickbar' sideOffset={8} onOpenAutoFocus={e => e.preventDefault()} hideWhenDetached={true}>
@@ -127,6 +132,9 @@ const Quickbar = ({ deleteAction, duplicateAction, createAction, createColumnAct
             {deleteAction && <Button icon={IvyIcons.Trash} aria-label='Delete' title='Delete' onClick={deleteAction} />}
             {duplicateAction && (
               <Button icon={IvyIcons.SubActivitiesDashed} aria-label='Duplicate' title='Duplicate' onClick={duplicateAction} />
+            )}
+            {(createColumnAction || createAction || createFromDataAction) && (
+              <Separator orientation='vertical' style={{ height: 20, margin: '0 var(--size-1)' }} />
             )}
             {createColumnAction && (
               <Button
@@ -138,19 +146,29 @@ const Quickbar = ({ deleteAction, duplicateAction, createAction, createColumnAct
               />
             )}
             {/* <Button icon={IvyIcons.ChangeType} title='Change Type' /> */}
-            {createAction && (
-              <>
-                <Separator orientation='vertical' style={{ height: 20, margin: '0 var(--size-1)' }} />
+            {createFromDataAction && (
+              <DataClassDialog worfkflowButtonsInit={false} creationTarget={createFromDataAction}>
                 <Button
-                  icon={IvyIcons.Task}
-                  aria-label='All Components'
-                  title='All Components'
+                  icon={IvyIcons.DatabaseLink}
+                  size='small'
+                  aria-label='Create from data'
+                  title='Create from data'
                   onClick={e => {
                     e.stopPropagation();
-                    setMenu(old => !old);
                   }}
                 />
-              </>
+              </DataClassDialog>
+            )}
+            {createAction && (
+              <Button
+                icon={IvyIcons.Task}
+                aria-label='All Components'
+                title='All Components'
+                onClick={e => {
+                  e.stopPropagation();
+                  setMenu(old => !old);
+                }}
+              />
             )}
           </Flex>
         </PopoverAnchor>

--- a/packages/editor/src/editor/canvas/data-class/DataClassDialog.tsx
+++ b/packages/editor/src/editor/canvas/data-class/DataClassDialog.tsx
@@ -23,22 +23,41 @@ import { useCallback, useEffect, useState, type ReactNode } from 'react';
 import type { Variable } from '@axonivy/form-editor-protocol';
 import { rowToCreateData, variableTreeData } from '../../../data/variable-tree-data';
 import { flexRender, getCoreRowModel, getFilteredRowModel, useReactTable, type ColumnDef, type Row } from '@tanstack/react-table';
-import { createInitForm } from '../../../data/data';
+import { createInitForm, STRUCTURE_DROPZONE_ID_PREFIX } from '../../../data/data';
 
-export const DataClassDialog = ({ children, worfkflowButtonsInit = true }: { children: ReactNode; worfkflowButtonsInit?: boolean }) => (
+export const DataClassDialog = ({
+  children,
+  worfkflowButtonsInit = true,
+  creationTarget
+}: {
+  children: ReactNode;
+  worfkflowButtonsInit?: boolean;
+  creationTarget?: string;
+}) => (
   <Dialog>
     <DialogTrigger asChild>{children}</DialogTrigger>
-    <DialogContent>
+    <DialogContent onClick={e => e.stopPropagation()}>
       <DialogHeader>
         <DialogTitle>Create from data</DialogTitle>
       </DialogHeader>
-      <DataClassSelect worfkflowButtonsInit={worfkflowButtonsInit} />
+      <DataClassSelect worfkflowButtonsInit={worfkflowButtonsInit} creationTarget={creationTarget} />
     </DialogContent>
   </Dialog>
 );
+export const getSelectedElementId = (selectedElementId: string | undefined) => {
+  if (
+    selectedElementId &&
+    (selectedElementId.startsWith('Layout') || selectedElementId.startsWith('Panel') || selectedElementId.startsWith('Fieldset'))
+  ) {
+    return STRUCTURE_DROPZONE_ID_PREFIX + selectedElementId;
+  } else {
+    return selectedElementId;
+  }
+};
 
-const DataClassSelect = ({ worfkflowButtonsInit }: { worfkflowButtonsInit: boolean }) => {
+export const DataClassSelect = ({ worfkflowButtonsInit, creationTarget }: { worfkflowButtonsInit: boolean; creationTarget?: string }) => {
   const { context, setData } = useAppContext();
+
   const [tree, setTree] = useState<Array<BrowserNode<Variable>>>([]);
   const [workflowButtons, setWorkflowButtons] = useState(worfkflowButtonsInit);
   const dataClass = useMeta('meta/data/attributes', context, { types: {}, variables: [] }).data;
@@ -87,7 +106,7 @@ const DataClassSelect = ({ worfkflowButtonsInit }: { worfkflowButtonsInit: boole
         .getSelectedRowModel()
         .flatRows.map(rowToCreateData)
         .filter(create => create !== undefined);
-      return createInitForm(data, creates, workflowButtons);
+      return createInitForm(data, creates, workflowButtons, creationTarget && getSelectedElementId(creationTarget));
     });
   };
   return (

--- a/packages/editor/src/types/config.ts
+++ b/packages/editor/src/types/config.ts
@@ -111,6 +111,6 @@ export type Config<Props extends { [key: string]: any } = { [key: string]: any }
   };
 };
 
-export type QuickAction = 'DELETE' | 'DUPLICATE' | 'CREATE' | 'CREATECOLUMN';
+export type QuickAction = 'DELETE' | 'DUPLICATE' | 'CREATE' | 'CREATEFROMDATA' | 'CREATECOLUMN';
 
-export const DEFAULT_QUICK_ACTIONS: Array<QuickAction> = ['DELETE', 'DUPLICATE', 'CREATE'] as const;
+export const DEFAULT_QUICK_ACTIONS: Array<QuickAction> = ['DELETE', 'DUPLICATE', 'CREATE', 'CREATEFROMDATA'] as const;


### PR DESCRIPTION
I improved the quickactions:
- I added to every component the "Create from Data" quickaction
- If it is a "normal" component, the new "Create from Data"-Components are added above
- If it is a Structure-Component (Layout/Fieldset/Panel), the new "Create from Data"-Components are added inside. (The same behaviour was also applied to the "Create"-Action)
- If you use the "Create from Data" from the Toolbar the components are still just added to the end of the canvas

![quickactionData](https://github.com/user-attachments/assets/9fd5e0c0-2a00-4563-a75c-d268abda8c7b)

_Quickaction for Datatable_
![grafik](https://github.com/user-attachments/assets/db06e7a6-6a10-4dc8-9e52-1f3aa3eb1ac9)
