### PR TITLE
Load browser meta not until needed (browser opens)

### DIFF
--- a/packages/editor/src/editor/sidebar/fields/InputFieldWithBrowser.tsx
+++ b/packages/editor/src/editor/sidebar/fields/InputFieldWithBrowser.tsx
@@ -1,12 +1,10 @@
-import { BasicField, BrowsersView, Button, Dialog, DialogContent, DialogTrigger, Input, InputGroup } from '@axonivy/ui-components';
+import { BasicField, Button, Dialog, DialogContent, DialogTrigger, Input, InputGroup } from '@axonivy/ui-components';
 import { IvyIcons } from '@axonivy/ui-icons';
 import { useRef, useState } from 'react';
-import { useAttributeBrowser } from './browser/useAttributeBrowser';
 import type { InputFieldProps } from './InputField';
-import type { Browser, TextBrowserFieldOptions } from '../../../types/config';
-import { useLogicBrowser } from './browser/useLogicBrowser';
+import type { TextBrowserFieldOptions } from '../../../types/config';
 import { focusBracketContent } from '../../../utils/focus';
-import { CMS_BROWSER_ID, useCmsBrowser } from './browser/useCmsBrowser';
+import { Browser, type BrowserType } from './browser/Browser';
 
 export const InputFieldWithBrowser = ({
   label,
@@ -16,19 +14,9 @@ export const InputFieldWithBrowser = ({
   onBlur,
   message,
   options
-}: InputFieldProps & { browsers: Browser[]; options?: TextBrowserFieldOptions }) => {
+}: InputFieldProps & { browsers: Array<BrowserType>; options?: TextBrowserFieldOptions }) => {
   const [open, setOpen] = useState(false);
   const inputRef = useRef<HTMLInputElement>(null);
-  const attrBrowser = useAttributeBrowser(options?.onlyAttributes, options?.onlyTypesOf);
-  const logicBrowser = useLogicBrowser();
-  const cmsBrowser = useCmsBrowser();
-
-  const activeBrowsers = [
-    ...(browsers.includes('ATTRIBUTE') ? [attrBrowser] : []),
-    ...(browsers.includes('LOGIC') ? [logicBrowser] : []),
-    ...(browsers.includes('CMS') ? [cmsBrowser] : [])
-  ];
-
   return (
     <Dialog open={open} onOpenChange={setOpen}>
       <BasicField label={label} message={message} style={{ flex: '1' }}>
@@ -41,19 +29,9 @@ export const InputFieldWithBrowser = ({
       </BasicField>
       <DialogContent
         style={{ height: '80vh' }}
-        onCloseAutoFocus={activeBrowsers.includes(logicBrowser) ? e => focusBracketContent(e, value, inputRef.current) : undefined}
+        onCloseAutoFocus={browsers.includes('LOGIC') ? e => focusBracketContent(e, value, inputRef.current) : undefined}
       >
-        <BrowsersView
-          browsers={activeBrowsers}
-          apply={(browserName, result) => {
-            if (result && browserName === CMS_BROWSER_ID) {
-              onChange(`${value}#{${result.value}}`);
-            } else if (result) {
-              onChange(options?.onlyAttributes || options?.directApply ? `${result.value}` : `#{${result.value}}`);
-            }
-            setOpen(false);
-          }}
-        />
+        <Browser activeBrowsers={browsers} close={() => setOpen(false)} value={value} onChange={onChange} options={options} />
       </DialogContent>
     </Dialog>
   );

--- a/packages/editor/src/editor/sidebar/fields/TextareaField.tsx
+++ b/packages/editor/src/editor/sidebar/fields/TextareaField.tsx
@@ -1,17 +1,7 @@
-import {
-  BasicField,
-  BrowsersView,
-  Button,
-  Dialog,
-  DialogContent,
-  DialogTrigger,
-  Flex,
-  Textarea,
-  type MessageData
-} from '@axonivy/ui-components';
+import { BasicField, Button, Dialog, DialogContent, DialogTrigger, Flex, Textarea, type MessageData } from '@axonivy/ui-components';
 import { useState } from 'react';
-import { useCmsBrowser } from './browser/useCmsBrowser';
 import { IvyIcons } from '@axonivy/ui-icons';
+import { Browser } from './browser/Browser';
 
 type TextareaFieldProps = {
   label: string;
@@ -22,8 +12,6 @@ type TextareaFieldProps = {
 
 export const TextareaField = ({ label, value, onChange, message }: TextareaFieldProps) => {
   const [open, setOpen] = useState(false);
-  const cmsBrowser = useCmsBrowser();
-
   return (
     <Dialog open={open} onOpenChange={setOpen}>
       <BasicField label={label} message={message}>
@@ -35,15 +23,7 @@ export const TextareaField = ({ label, value, onChange, message }: TextareaField
         </Flex>
       </BasicField>
       <DialogContent style={{ height: '80vh' }}>
-        <BrowsersView
-          browsers={[cmsBrowser]}
-          apply={(browserName, result) => {
-            if (result) {
-              onChange(`${value}#{${result.value}}`);
-            }
-            setOpen(false);
-          }}
-        />
+        <Browser activeBrowsers={['CMS']} close={() => setOpen(false)} value={value} onChange={onChange} />
       </DialogContent>
     </Dialog>
   );

--- a/packages/editor/src/editor/sidebar/fields/browser/Browser.tsx
+++ b/packages/editor/src/editor/sidebar/fields/browser/Browser.tsx
@@ -1,0 +1,48 @@
+import { BrowsersView } from '@axonivy/ui-components';
+import { CMS_BROWSER_ID, useCmsBrowser } from './useCmsBrowser';
+import { useAttributeBrowser } from './useAttributeBrowser';
+import { useLogicBrowser } from './useLogicBrowser';
+
+type OnlyAttributeSelection = 'DYNAMICLIST' | 'COLUMN';
+
+export type BrowserType = 'ATTRIBUTE' | 'LOGIC' | 'CMS';
+
+export type BrowserOptions = {
+  onlyTypesOf?: string;
+  onlyAttributes?: OnlyAttributeSelection;
+  directApply?: boolean;
+};
+
+type BrowserProps = {
+  value: string;
+  onChange: (value: string) => void;
+  activeBrowsers: Array<BrowserType>;
+  close: () => void;
+  options?: BrowserOptions;
+};
+
+export const Browser = ({ value, onChange, activeBrowsers, close, options }: BrowserProps) => {
+  const attrBrowser = useAttributeBrowser(options);
+  const logicBrowser = useLogicBrowser();
+  const cmsBrowser = useCmsBrowser();
+
+  const browsers = [
+    ...(activeBrowsers.includes('ATTRIBUTE') ? [attrBrowser] : []),
+    ...(activeBrowsers.includes('LOGIC') ? [logicBrowser] : []),
+    ...(activeBrowsers.includes('CMS') ? [cmsBrowser] : [])
+  ];
+
+  return (
+    <BrowsersView
+      browsers={browsers}
+      apply={(browserName, result) => {
+        if (result && browserName === CMS_BROWSER_ID) {
+          onChange(`${value}#{${result.value}}`);
+        } else if (result) {
+          onChange(options?.onlyAttributes || options?.directApply ? result.value : `#{${result.value}}`);
+        }
+        close();
+      }}
+    />
+  );
+};

--- a/packages/editor/src/editor/sidebar/fields/browser/useCmsBrowser.tsx
+++ b/packages/editor/src/editor/sidebar/fields/browser/useCmsBrowser.tsx
@@ -1,7 +1,7 @@
 import { BasicCheckbox, useBrowser, type Browser, type BrowserNode } from '@axonivy/ui-components';
 import { IvyIcons } from '@axonivy/ui-icons';
 import { useMeta } from '../../../../context/useMeta';
-import { useEffect, useState } from 'react';
+import { useMemo, useState } from 'react';
 import type { ContentObject } from '@axonivy/form-editor-protocol';
 import { useAppContext } from '../../../../context/AppContext';
 import { cmsTreeData } from '../../../../data/cms-tree-data';
@@ -10,20 +10,15 @@ import type { Row } from '@tanstack/react-table';
 export const CMS_BROWSER_ID = 'CMS' as const;
 
 export const useCmsBrowser = (): Browser => {
-  const [tree, setTree] = useState<Array<BrowserNode<ContentObject>>>([]);
   const [requiredProject, setRequiredProject] = useState<boolean>(false);
   const { context } = useAppContext();
   const cmsTree = useMeta('meta/data/cms', { context, requiredProjects: requiredProject }, []).data;
-
-  useEffect(() => {
-    setTree(cmsTreeData(cmsTree));
-  }, [cmsTree]);
-
-  const cms = useBrowser(tree, undefined, '', true);
+  const tree = useMemo(() => cmsTreeData(cmsTree), [cmsTree]);
+  const browser = useBrowser(tree, undefined, '', true);
   return {
     name: CMS_BROWSER_ID,
     icon: IvyIcons.Process,
-    browser: cms,
+    browser,
     header: (
       <BasicCheckbox
         label='Enable required Projects'
@@ -31,7 +26,6 @@ export const useCmsBrowser = (): Browser => {
         onCheckedChange={() => setRequiredProject(!requiredProject)}
       />
     ),
-
     infoProvider: row => <CmsInfoProvider row={row} />,
     applyModifier: row => ({ value: `ivy.cms.co('${(row.original.data as ContentObject).fullPath}')` })
   };

--- a/packages/editor/src/editor/sidebar/fields/browser/useLogicBrowser.tsx
+++ b/packages/editor/src/editor/sidebar/fields/browser/useLogicBrowser.tsx
@@ -1,7 +1,7 @@
-import { useBrowser, type Browser, type BrowserNode } from '@axonivy/ui-components';
+import { useBrowser, type Browser } from '@axonivy/ui-components';
 import { IvyIcons } from '@axonivy/ui-icons';
 import { useMeta } from '../../../../context/useMeta';
-import { useEffect, useState } from 'react';
+import { useMemo } from 'react';
 import type { LogicMethodInfo } from '@axonivy/form-editor-protocol';
 import { useAppContext } from '../../../../context/AppContext';
 import { formatLogicMethodInfo, logicTreeData } from '../../../../data/logic-tree-data';
@@ -9,19 +9,14 @@ import { formatLogicMethodInfo, logicTreeData } from '../../../../data/logic-tre
 export const LOGIC_BROWSER_ID = 'Logic' as const;
 
 export const useLogicBrowser = (): Browser => {
-  const [tree, setTree] = useState<Array<BrowserNode<LogicMethodInfo>>>([]);
   const { context } = useAppContext();
   const logicInfo = useMeta('meta/data/logic', context, { startMethods: [], eventStarts: [] }).data;
-
-  useEffect(() => {
-    setTree(logicTreeData(logicInfo));
-  }, [logicInfo, logicInfo.startMethods]);
-
-  const logic = useBrowser(tree, undefined, '', true);
+  const tree = useMemo(() => logicTreeData(logicInfo), [logicInfo]);
+  const browser = useBrowser(tree, undefined, '', true);
   return {
     name: LOGIC_BROWSER_ID,
     icon: IvyIcons.Process,
-    browser: logic,
+    browser,
     infoProvider: row => (row?.original.data ? formatLogicMethodInfo(row?.original.data as LogicMethodInfo) : row?.original.info),
     applyModifier: row => ({ value: 'logic.' + row.original.value })
   };

--- a/packages/editor/src/types/config.ts
+++ b/packages/editor/src/types/config.ts
@@ -1,6 +1,7 @@
 import type { ComponentType, ConfigData, PrimitiveValue } from '@axonivy/form-editor-protocol';
 import type React from 'react';
 import type { ReactNode } from 'react';
+import type { BrowserOptions, BrowserType } from '../editor/sidebar/fields/browser/Browser';
 
 export type UiComponentProps<Props extends DefaultComponentProps = DefaultComponentProps> = Props & { id: string };
 
@@ -35,14 +36,7 @@ export type TextFieldOptions = {
   disabled?: boolean;
 };
 
-export type OnlyAttributeSelection = 'DYNAMICLIST' | 'COLUMN';
-export type Browser = 'ATTRIBUTE' | 'LOGIC' | 'CMS';
-
-export type TextBrowserFieldOptions = TextFieldOptions & {
-  onlyTypesOf?: string;
-  onlyAttributes?: OnlyAttributeSelection;
-  directApply?: boolean;
-};
+export type TextBrowserFieldOptions = TextFieldOptions & BrowserOptions;
 
 export type TextField<ComponentProps extends DefaultComponentProps = DefaultComponentProps> = BaseField<ComponentProps> & {
   type: 'text' | 'number' | 'textarea' | 'checkbox' | 'textConditionBuilder';
@@ -51,7 +45,7 @@ export type TextField<ComponentProps extends DefaultComponentProps = DefaultComp
 
 export type TextBrowserField<ComponentProps extends DefaultComponentProps = DefaultComponentProps> = BaseField<ComponentProps> & {
   type: 'textBrowser';
-  browsers: Browser[];
+  browsers: Array<BrowserType>;
   options?: TextBrowserFieldOptions;
 };
 

--- a/playwright/form-test-project/cms/cms_en.yaml
+++ b/playwright/form-test-project/cms/cms_en.yaml
@@ -1,0 +1,1 @@
+greetings: Hello World


### PR DESCRIPTION
Before:
![Screen Recording 2024-10-10 at 16 09 24](https://github.com/user-attachments/assets/64b9f2a6-2d7d-4a6f-bbb8-cc62051c846c)

After:
![Screen Recording 2024-10-10 at 16 08 18](https://github.com/user-attachments/assets/b725d756-4398-4094-a99a-5368faed5c2f)

Other side effect, meta only requested once (see before, tanstack query count of current data listener, for each browser input filed one)