### PR TITLE
XIVY-15123 Add Cms QuickActions to Input

### DIFF
--- a/integrations/standalone/src/mock/form-client-mock.ts
+++ b/integrations/standalone/src/mock/form-client-mock.ts
@@ -45,6 +45,10 @@ export class FormClientMock implements FormClient {
         return Promise.resolve(MetaMock.COMPOSITES);
       case 'meta/composite/params':
         return Promise.resolve(MetaMock.COMPOSITE_PARAMS);
+      case 'meta/cms/cmsQuickActions':
+        return Promise.resolve(MetaMock.CMSQUICKACTIONS);
+      case 'meta/cms/executeCmsQuickAction':
+        return Promise.resolve("#{ivy.cms.co('/Labels/Firstname')}");
       case 'meta/data/logic':
       default:
         throw Error('mock meta path not programmed');

--- a/integrations/standalone/src/mock/meta-mock.ts
+++ b/integrations/standalone/src/mock/meta-mock.ts
@@ -1,4 +1,4 @@
-import type { CompositeInfo, ParameterInfo, VariableInfo } from '@axonivy/form-editor-protocol';
+import type { CmsQuickAction, CompositeInfo, ParameterInfo, VariableInfo } from '@axonivy/form-editor-protocol';
 
 export namespace MetaMock {
   export const ATTRIBUTES: VariableInfo = {
@@ -91,6 +91,21 @@ export namespace MetaMock {
           deprecated: false
         }
       ]
+    }
+  ];
+
+  export const CMSQUICKACTIONS: Array<CmsQuickAction> = [
+    {
+      category: 'global',
+      coContent: '',
+      coName: 'Firstname',
+      parentUri: '/Labels/'
+    },
+    {
+      category: 'local',
+      coContent: '',
+      coName: 'Firstname',
+      parentUri: '/Dialogs/'
     }
   ];
 

--- a/packages/editor/src/context/useFunction.ts
+++ b/packages/editor/src/context/useFunction.ts
@@ -1,0 +1,24 @@
+import { useMutation, type UseMutationResult } from '@tanstack/react-query';
+import { genQueryKey } from '../query/query-client';
+import { useClient } from './ClientContext';
+import type { FormMetaRequestTypes } from '@axonivy/form-editor-protocol';
+
+type UseFunctionOptions<TData> = {
+  onSuccess?: (data: TData) => void;
+  onError?: (error: Error) => void;
+};
+
+export function useFunction<TFunct extends keyof FormMetaRequestTypes>(
+  path: TFunct,
+  initialArgs: FormMetaRequestTypes[TFunct][0],
+  options?: UseFunctionOptions<FormMetaRequestTypes[TFunct][1]>
+): UseMutationResult<FormMetaRequestTypes[TFunct][1], Error, FormMetaRequestTypes[TFunct][0] | undefined> {
+  const client = useClient();
+
+  return useMutation({
+    mutationKey: genQueryKey(path, initialArgs),
+    mutationFn: (args?: FormMetaRequestTypes[TFunct][0]) => client.meta(path, args ?? initialArgs),
+    onSuccess: options?.onSuccess,
+    onError: options?.onError
+  });
+}

--- a/packages/editor/src/editor/browser/cms/AddCmsQuickAction.tsx
+++ b/packages/editor/src/editor/browser/cms/AddCmsQuickAction.tsx
@@ -1,0 +1,91 @@
+import { useState } from 'react';
+import { useMeta } from '../../../context/useMeta';
+import { Button, Flex, Popover, PopoverArrow, PopoverContent, PopoverTrigger, toast } from '@axonivy/ui-components';
+import { IvyIcons } from '@axonivy/ui-icons';
+import { useAppContext } from '../../../context/AppContext';
+import { useFunction } from '../../../context/useFunction';
+import { useQueryClient } from '@tanstack/react-query';
+import { genQueryKey } from '../../../query/query-client';
+
+export const AddCmsQuickActionPopover = ({
+  value,
+  onChange,
+  savedSelection,
+  inputRef
+}: {
+  value: string;
+  onChange: (value: string) => void;
+  savedSelection: { start: number; end: number };
+  inputRef: React.RefObject<HTMLInputElement>;
+}) => {
+  const [open, setOpen] = useState(false);
+
+  const { context } = useAppContext();
+  const queryClient = useQueryClient();
+  const cmsQuickActions = useMeta('meta/cms/cmsQuickActions', { context, text: value }, []).data;
+  const executeCmsQuickAction = useFunction(
+    'meta/cms/executeCmsQuickAction',
+    {
+      context,
+      cmsQuickAction: { category: 'global', coContent: '', coName: '', parentUri: '' }
+    },
+    {
+      onSuccess: data => {
+        toast.info('Content Object was successfully created ' + data);
+        queryClient.invalidateQueries({ queryKey: genQueryKey('meta/cms/cmsTree', { context, requiredProjects: false }) });
+        queryClient.invalidateQueries({
+          queryKey: genQueryKey('meta/cms/cmsQuickActions', { context, text: value })
+        });
+        if (inputRef.current && savedSelection) {
+          const currentValue = inputRef.current.value;
+          const newValue = currentValue.slice(0, savedSelection.start) + data + currentValue.slice(savedSelection.end);
+
+          onChange(newValue);
+          setOpen(false);
+        }
+      },
+      onError: error => {
+        toast.error('Failed to create Content Object', { description: error.message });
+      }
+    }
+  );
+
+  const restoreSelection = (e: Event) => {
+    e.preventDefault();
+    if (inputRef.current && savedSelection) {
+      inputRef.current.setSelectionRange(savedSelection.start, savedSelection.end);
+      inputRef.current.focus();
+    }
+  };
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger asChild>
+        <Button icon={IvyIcons.Cms} aria-label='CMS-Quickaction' title='CMS-Quickaction' />
+      </PopoverTrigger>
+      <PopoverContent sideOffset={12} collisionPadding={5} onOpenAutoFocus={restoreSelection} onFocusOutside={e => e.preventDefault()}>
+        <Flex direction='column' gap={2} alignItems='center'>
+          {value.length > 0 &&
+            cmsQuickActions?.map((action, index) => (
+              <Button
+                key={index}
+                icon={IvyIcons.Cms}
+                aria-label={`CMS-Quickaction-${action.category}`}
+                title={`Create content object: '${action.parentUri}${action.coName}' value: ${action.coContent}`}
+                onClick={() => {
+                  executeCmsQuickAction.mutate({
+                    context,
+                    cmsQuickAction: action
+                  });
+                }}
+                style={{ width: '100%', justifyContent: 'start' }}
+              >
+                {`Create ${action.category} '${action.coName}'`}
+              </Button>
+            ))}
+        </Flex>
+        <PopoverArrow />
+      </PopoverContent>
+    </Popover>
+  );
+};

--- a/packages/editor/src/editor/browser/cms/useCmsBrowser.tsx
+++ b/packages/editor/src/editor/browser/cms/useCmsBrowser.tsx
@@ -1,18 +1,19 @@
 import { BasicCheckbox, useBrowser, type Browser, type BrowserNode } from '@axonivy/ui-components';
+import type { Row } from '@tanstack/react-table';
+
 import { IvyIcons } from '@axonivy/ui-icons';
 import { useMeta } from '../../../context/useMeta';
 import { useMemo, useState } from 'react';
 import type { ContentObject } from '@axonivy/form-editor-protocol';
 import { useAppContext } from '../../../context/AppContext';
 import { cmsTreeData } from './cms-tree-data';
-import type { Row } from '@tanstack/react-table';
 
 export const CMS_BROWSER_ID = 'CMS' as const;
 
 export const useCmsBrowser = (): Browser => {
   const [requiredProject, setRequiredProject] = useState<boolean>(false);
   const { context } = useAppContext();
-  const cmsTree = useMeta('meta/data/cms', { context, requiredProjects: requiredProject }, []).data;
+  const cmsTree = useMeta('meta/cms/cmsTree', { context, requiredProjects: requiredProject }, []).data;
   const tree = useMemo(() => cmsTreeData(cmsTree), [cmsTree]);
   const browser = useBrowser(tree, { expandedState: true });
   return {

--- a/packages/editor/src/editor/sidebar/fields/InputFieldWithBrowser.tsx
+++ b/packages/editor/src/editor/sidebar/fields/InputFieldWithBrowser.tsx
@@ -5,6 +5,7 @@ import type { InputFieldProps } from './InputField';
 import type { TextBrowserFieldOptions } from '../../../types/config';
 import { focusBracketContent } from '../../../utils/focus';
 import { Browser, type BrowserType } from '../../browser/Browser';
+import { AddCmsQuickActionPopover } from '../../browser/cms/AddCmsQuickAction';
 
 export const InputFieldWithBrowser = ({
   label,
@@ -16,12 +17,44 @@ export const InputFieldWithBrowser = ({
   options
 }: InputFieldProps & { browsers: Array<BrowserType>; options?: TextBrowserFieldOptions }) => {
   const [open, setOpen] = useState(false);
+  const [savedSelection, setSavedSelection] = useState<{ start: number; end: number } | undefined>();
+
   const inputRef = useRef<HTMLInputElement>(null);
+  const handleTextSelection = () => {
+    if (inputRef.current) {
+      const selectionStart = inputRef.current.selectionStart ?? 0;
+      const selectionEnd = inputRef.current.selectionEnd ?? 0;
+      if (selectionStart !== selectionEnd) {
+        setSavedSelection({ start: selectionStart, end: selectionEnd });
+      } else {
+        setSavedSelection(undefined);
+      }
+    }
+  };
+
+  const getSelectedText = () => {
+    if (inputRef.current && savedSelection) {
+      const text = inputRef.current.value.substring(savedSelection.start, savedSelection.end);
+      return text;
+    }
+    return '';
+  };
+
   return (
     <Dialog open={open} onOpenChange={setOpen}>
       <BasicField label={label} message={message} style={{ flex: '1' }}>
         <InputGroup>
-          <Input ref={inputRef} value={value} onChange={e => onChange(e.target.value)} onBlur={onBlur} placeholder={options?.placeholder} />
+          <Input
+            ref={inputRef}
+            value={value}
+            onChange={e => onChange(e.target.value)}
+            onSelect={handleTextSelection}
+            onBlur={onBlur}
+            placeholder={options?.placeholder}
+          />
+          {browsers.some(b => b === 'CMS') && inputRef.current?.selectionStart !== inputRef.current?.selectionEnd && savedSelection && (
+            <AddCmsQuickActionPopover value={getSelectedText()} savedSelection={savedSelection} inputRef={inputRef} onChange={onChange} />
+          )}
           <DialogTrigger asChild>
             <Button icon={IvyIcons.ListSearch} aria-label='Browser' />
           </DialogTrigger>

--- a/packages/protocol/src/data/form.ts
+++ b/packages/protocol/src/data/form.ts
@@ -6,7 +6,8 @@
  * and run json-schema-to-typescript to regenerate this file.
  */
 
-export type ContentObjectType = ("STRING" | "FILE" | "FOLDER")
+export type CmsQuickactionCategory = ("global" | "local")
+export type ContentObjectType = "STRING" | "FILE" | "FOLDER";
 export type ButtonVariant = "PRIMARY" | "SECONDARY" | "DANGER";
 export type SymbolPosition = "p" | "s";
 export type InputType = "TEXT" | "EMAIL" | "PASSWORD" | "NUMBER";
@@ -20,9 +21,12 @@ export type Severity = "INFO" | "WARNING" | "ERROR";
 
 export interface Forms {
   cmsMetaRequest: CmsMetaRequest;
+  cmsQuickAction: CmsQuickAction[];
+  cmsQuickActionRequest: CmsQuickActionRequest;
   compositeContext: CompositeContext;
   compositeInfo: CompositeInfo[];
   contentObject: ContentObject[];
+  executeCmsQuickActionRequest: ExecuteCmsQuickActionRequest;
   form: Form;
   formActionArgs: FormActionArgs;
   formContext: FormContext;
@@ -31,7 +35,7 @@ export interface Forms {
   formSaveDataArgs: FormSaveDataArgs;
   logicInfo: LogicInfo;
   parameterInfo: ParameterInfo[];
-  string: string[];
+  string: string;
   validationResult: ValidationResult[];
   variableInfo: VariableInfo;
   void: Void;
@@ -45,6 +49,16 @@ export interface FormContext {
   app: string;
   file: string;
   pmv: string;
+}
+export interface CmsQuickAction {
+  category: CmsQuickactionCategory;
+  coContent: string;
+  coName: string;
+  parentUri: string;
+}
+export interface CmsQuickActionRequest {
+  context: FormContext;
+  text: string;
 }
 export interface CompositeContext {
   compositeId: string;
@@ -73,6 +87,10 @@ export interface ContentObject {
 }
 export interface MapStringString {
   [k: string]: string;
+}
+export interface ExecuteCmsQuickActionRequest {
+  cmsQuickAction: CmsQuickAction;
+  context: FormContext;
 }
 export interface Form {
   $schema: string;

--- a/packages/protocol/src/form-protocol.ts
+++ b/packages/protocol/src/form-protocol.ts
@@ -8,14 +8,19 @@ import type {
   ParameterInfo,
   CompositeContext,
   ValidationResult,
-  FormActionArgs
+  FormActionArgs,
+  CmsQuickActionRequest,
+  CmsQuickAction,
+  ExecuteCmsQuickActionRequest
 } from './data/form';
 import type { FormEditor, FormSaveData } from './data/form-data';
 
 export interface FormMetaRequestTypes {
   'meta/data/attributes': [FormContext, VariableInfo];
   'meta/data/logic': [FormContext, LogicInfo];
-  'meta/data/cms': [CmsMetaRequest, Array<ContentObject>];
+  'meta/cms/cmsTree': [CmsMetaRequest, Array<ContentObject>];
+  'meta/cms/executeCmsQuickAction': [ExecuteCmsQuickActionRequest, string];
+  'meta/cms/cmsQuickActions': [CmsQuickActionRequest, Array<CmsQuickAction>];
   'meta/composite/all': [FormContext, Array<CompositeInfo>];
   'meta/composite/params': [CompositeContext, Array<ParameterInfo>];
 }

--- a/playwright/tests/integration/properties/input.spec.ts
+++ b/playwright/tests/integration/properties/input.spec.ts
@@ -49,3 +49,16 @@ test('id', async ({ page }) => {
   await expect(id.locator).toHaveAttribute('placeholder', 'Input1');
   await id.expectEmpty();
 });
+
+test('cmsQuickaction', async ({ page }) => {
+  const editor = await FormEditor.openMock(page);
+  await editor.canvas.blockByNth(0).inscribe();
+  await editor.inscription.expectHeader('Input');
+  const properties = editor.inscription.section('Properties');
+  const section = properties.collapsible('General');
+  const label = section.input({ label: 'Label' });
+
+  await label.expectValue('Firstname');
+  await label.selectText();
+  await label.openQuickaction();
+});

--- a/playwright/tests/page-objects/inscription.ts
+++ b/playwright/tests/page-objects/inscription.ts
@@ -188,6 +188,28 @@ export class Input {
   async expectEmpty() {
     await expect(this.locator).toBeEmpty();
   }
+
+  async selectText() {
+    await this.locator.evaluate((input: HTMLInputElement) => input.select());
+    await this.locator.click();
+  }
+
+  async openQuickaction() {
+    await this.page.getByRole('button', { name: 'CMS-Quickaction' }).click();
+
+    const popover = this.page.locator('[role="dialog"][data-state="open"]').nth(1);
+    await expect(popover).toBeVisible();
+
+    const localButton = popover.getByRole('button', { name: 'CMS-Quickaction-local' });
+    const globalButton = popover.getByRole('button', { name: 'CMS-Quickaction-global' });
+
+    await expect(localButton).toBeVisible();
+    await expect(globalButton).toBeVisible();
+
+    await globalButton.click();
+    await expect(popover).not.toBeVisible();
+    await this.expectValue("#{ivy.cms.co('/Labels/Firstname')}");
+  }
 }
 
 class Checkbox {


### PR DESCRIPTION
I have now integrated the CMS quick action directly into the input field (it will only be displayed for input fields that have a CMS browser). As soon as something is selected, the popover trigger for the quick actions will be shown.

What's missing is the ability to change the coName of the newly created content object (this was possible with the old quick actions). If this is still desired, I could, for example, implement this in a later PR. What do you think?

![cmsAddQuickaction](https://github.com/user-attachments/assets/19c09549-9d50-4762-958f-08ae4ad0dee9)
