### PR TITLE
fix IT cmsQuickaction

### DIFF
--- a/playwright/tests/page-objects/inscription.ts
+++ b/playwright/tests/page-objects/inscription.ts
@@ -190,8 +190,7 @@ export class Input {
   }
 
   async selectText() {
-    this.locator.click();
-    this.locator.selectText();
+    await this.locator.dblclick();
   }
 
   async openQuickaction() {


### PR DESCRIPTION
For inexplicable reasons, the selectText() function in firefox did not trigger the CMS quickaction button in the input field. I am now doing the select manually as it seems to work this way. What do you think?

Strangely enough, the IT works for me locally with the previous solution without any problems on all browsers.