### PR TITLE
XIVY-15123 Add CMS-Quickaction to Textarea and add other improvements

### DIFF
--- a/packages/editor/src/editor/browser/cms/AddCmsQuickFix.tsx
+++ b/packages/editor/src/editor/browser/cms/AddCmsQuickFix.tsx
@@ -6,24 +6,25 @@ import { useAppContext } from '../../../context/AppContext';
 import { useFunction } from '../../../context/useFunction';
 import { useQueryClient } from '@tanstack/react-query';
 import { genQueryKey } from '../../../query/query-client';
+import type { InputTextAreaRef, Selection } from './useTextSelection';
 
-export const AddCmsQuickActionPopover = ({
+export const AddCmsQuickFixPopover = ({
   value,
   onChange,
-  savedSelection,
+  selection,
   inputRef
 }: {
   value: string;
   onChange: (value: string) => void;
-  savedSelection: { start: number; end: number };
-  inputRef: React.RefObject<HTMLInputElement>;
+  selection: Selection;
+  inputRef: InputTextAreaRef;
 }) => {
   const [open, setOpen] = useState(false);
 
   const { context } = useAppContext();
   const queryClient = useQueryClient();
-  const cmsQuickActions = useMeta('meta/cms/cmsQuickActions', { context, text: value }, []).data;
-  const executeCmsQuickAction = useFunction(
+  const cmsQuickFixes = useMeta('meta/cms/cmsQuickActions', { context, text: value }, []).data;
+  const executeCmsQuickFix = useFunction(
     'meta/cms/executeCmsQuickAction',
     {
       context,
@@ -36,9 +37,9 @@ export const AddCmsQuickActionPopover = ({
         queryClient.invalidateQueries({
           queryKey: genQueryKey('meta/cms/cmsQuickActions', { context, text: value })
         });
-        if (inputRef.current && savedSelection) {
+        if (inputRef.current && selection) {
           const currentValue = inputRef.current.value;
-          const newValue = currentValue.slice(0, savedSelection.start) + data + currentValue.slice(savedSelection.end);
+          const newValue = currentValue.slice(0, selection.start) + data + currentValue.slice(selection.end);
 
           onChange(newValue);
           setOpen(false);
@@ -52,8 +53,8 @@ export const AddCmsQuickActionPopover = ({
 
   const restoreSelection = (e: Event) => {
     e.preventDefault();
-    if (inputRef.current && savedSelection) {
-      inputRef.current.setSelectionRange(savedSelection.start, savedSelection.end);
+    if (inputRef.current && selection) {
+      inputRef.current.setSelectionRange(selection.start, selection.end);
       inputRef.current.focus();
     }
   };
@@ -61,26 +62,26 @@ export const AddCmsQuickActionPopover = ({
   return (
     <Popover open={open} onOpenChange={setOpen}>
       <PopoverTrigger asChild>
-        <Button icon={IvyIcons.Cms} aria-label='CMS-Quickaction' title='CMS-Quickaction' />
+        <Button icon={IvyIcons.Cms} aria-label='CMS-Quickfix' title='CMS-Quickfix' />
       </PopoverTrigger>
       <PopoverContent sideOffset={12} collisionPadding={5} onOpenAutoFocus={restoreSelection} onFocusOutside={e => e.preventDefault()}>
         <Flex direction='column' gap={2} alignItems='center'>
           {value.length > 0 &&
-            cmsQuickActions?.map((action, index) => (
+            cmsQuickFixes?.map((fix, index) => (
               <Button
                 key={index}
                 icon={IvyIcons.Cms}
-                aria-label={`CMS-Quickaction-${action.category}`}
-                title={`Create content object: '${action.parentUri}${action.coName}' value: ${action.coContent}`}
+                aria-label={`CMS-Quickfix-${fix.category}`}
+                title={`Create content object: '${fix.parentUri}${fix.coName}' value: ${fix.coContent}`}
                 onClick={() => {
-                  executeCmsQuickAction.mutate({
+                  executeCmsQuickFix.mutate({
                     context,
-                    cmsQuickAction: action
+                    cmsQuickAction: fix
                   });
                 }}
                 style={{ width: '100%', justifyContent: 'start' }}
               >
-                {`Create ${action.category} '${action.coName}'`}
+                {`Create ${fix.category} CMS-Object: '${fix.coName}'`}
               </Button>
             ))}
         </Flex>

--- a/packages/editor/src/editor/browser/cms/useTextSelection.test.ts
+++ b/packages/editor/src/editor/browser/cms/useTextSelection.test.ts
@@ -1,0 +1,108 @@
+import { describe, test, expect } from 'vitest';
+import { renderHook } from '@testing-library/react';
+import useTextSelection, { type InputTextAreaRef } from './useTextSelection';
+import { act } from 'react';
+
+const mockRef = (value: string, selectionStart: number | null, selectionEnd: number | null) => {
+  return {
+    current: {
+      value,
+      selectionStart,
+      selectionEnd
+    }
+  } as InputTextAreaRef;
+};
+
+describe('handleTextSelection', () => {
+  test('save selection if start and end are different', () => {
+    const ref = mockRef('sample text', 2, 6);
+
+    const { result } = renderHook(() => useTextSelection(ref));
+    act(() => result.current.handleTextSelection());
+
+    expect(result.current.selection).toEqual({ start: 2, end: 6 });
+  });
+
+  test('set undefined if start and end are the same', () => {
+    const ref = mockRef('sample text', 3, 3);
+    const { result } = renderHook(() => useTextSelection(ref));
+    act(() => result.current.handleTextSelection());
+
+    expect(result.current.selection).toBeUndefined();
+  });
+
+  test('do nothing if ref is null', () => {
+    const ref = { current: null } as InputTextAreaRef;
+    const { result } = renderHook(() => useTextSelection(ref));
+    act(() => result.current.handleTextSelection());
+
+    expect(result.current.selection).toBeUndefined();
+  });
+
+  test('return selected text based on saved selection', () => {
+    const ref = mockRef('sample text', 2, 6);
+    const { result } = renderHook(() => useTextSelection(ref));
+    act(() => result.current.handleTextSelection());
+
+    expect(result.current.getSelectedText()).toBe('mple');
+  });
+});
+
+describe('getSelectedText', () => {
+  test('return empty string if no selection is saved', () => {
+    const ref = mockRef('sample text', null, null);
+    const { result } = renderHook(() => useTextSelection(ref));
+
+    expect(result.current.getSelectedText()).toBe('');
+  });
+
+  test('return empty string if ref is null', () => {
+    const ref = { current: null } as InputTextAreaRef;
+    const { result } = renderHook(() => useTextSelection(ref));
+
+    expect(result.current.getSelectedText()).toBe('');
+  });
+});
+
+describe('showQuickFix', () => {
+  test('return false if no selection is saved', () => {
+    const ref = mockRef('sample text', null, null);
+    const { result } = renderHook(() => useTextSelection(ref));
+
+    expect(result.current.showQuickFix()).toBe(false);
+  });
+
+  test('return false if selected text contains only whitespace', () => {
+    const ref = mockRef('     ', 0, 5);
+    const { result } = renderHook(() => useTextSelection(ref));
+    act(() => result.current.handleTextSelection());
+
+    expect(result.current.showQuickFix()).toBe(false);
+  });
+
+  test('return false if selection contains "#{ }" brackets', () => {
+    const ref = mockRef('some #{text} here', 5, 12);
+    const { result } = renderHook(() => useTextSelection(ref));
+    act(() => result.current.handleTextSelection());
+
+    expect(result.current.getSelectedText()).toBe('#{text}');
+    expect(result.current.showQuickFix()).toBe(false);
+  });
+
+  test('return false if selection is surrounded by "#{ }" brackets', () => {
+    const ref = mockRef('some #{text} here', 7, 9);
+    const { result } = renderHook(() => useTextSelection(ref));
+    act(() => result.current.handleTextSelection());
+
+    expect(result.current.getSelectedText()).toBe('te');
+    expect(result.current.showQuickFix()).toBe(false);
+  });
+
+  test('return true if selection meets all criteria', () => {
+    const ref = mockRef('some random text without brackets', 5, 11);
+    const { result } = renderHook(() => useTextSelection(ref));
+    act(() => result.current.handleTextSelection());
+
+    expect(result.current.showQuickFix()).toBe(true);
+  });
+});

--- a/packages/editor/src/editor/browser/cms/useTextSelection.ts
+++ b/packages/editor/src/editor/browser/cms/useTextSelection.ts
@@ -1,0 +1,63 @@
+import { useState } from 'react';
+
+export type Selection = { start: number; end: number };
+export type InputTextAreaRef = React.RefObject<HTMLInputElement> | React.RefObject<HTMLTextAreaElement>;
+
+const useTextSelection = (ref: InputTextAreaRef) => {
+  const [selection, setSelection] = useState<Selection | undefined>(undefined);
+  const handleTextSelection = () => {
+    if (ref.current) {
+      const selectionStart = ref.current.selectionStart ?? 0;
+      const selectionEnd = ref.current.selectionEnd ?? 0;
+      if (selectionStart !== selectionEnd) {
+        setSelection({ start: selectionStart, end: selectionEnd });
+      } else {
+        setSelection(undefined);
+      }
+    }
+  };
+
+  const getSelectedText = () => {
+    if (ref.current && selection) {
+      return ref.current.value.substring(selection.start, selection.end);
+    }
+    return '';
+  };
+
+  const showQuickFix = () => {
+    if (!selection || !ref.current) {
+      return false;
+    }
+
+    const selectedText = getSelectedText();
+    const fullText = ref.current.value;
+
+    // Check if selectedText contains only whitespace
+    const selectedTextWithoutWhitespace = selectedText.replace(/\s/g, '');
+    if (selectedTextWithoutWhitespace.length === 0) {
+      return false;
+    }
+
+    // Check if selection contains #{ }
+    const containsBrackets = selectedText.includes('#{') && selectedText.includes('}');
+    if (containsBrackets) {
+      return false;
+    }
+
+    // Check if selection is not surrounded by #{ }
+    const textBeforeSelection = fullText.substring(0, selection.start);
+    const hasOpeningBracketBefore = textBeforeSelection.includes('#{');
+    const textAfterSelection = fullText.substring(selection.end);
+    const hasClosingBracketAfter = textAfterSelection.includes('}');
+    return !(hasOpeningBracketBefore && hasClosingBracketAfter);
+  };
+
+  return {
+    selection,
+    handleTextSelection,
+    getSelectedText,
+    showQuickFix
+  };
+};
+
+export default useTextSelection;

--- a/packages/editor/src/editor/sidebar/fields/InputFieldWithBrowser.tsx
+++ b/packages/editor/src/editor/sidebar/fields/InputFieldWithBrowser.tsx
@@ -5,7 +5,8 @@ import type { InputFieldProps } from './InputField';
 import type { TextBrowserFieldOptions } from '../../../types/config';
 import { focusBracketContent } from '../../../utils/focus';
 import { Browser, type BrowserType } from '../../browser/Browser';
-import { AddCmsQuickActionPopover } from '../../browser/cms/AddCmsQuickAction';
+import { AddCmsQuickFixPopover } from '../../browser/cms/AddCmsQuickFix';
+import useTextSelection from '../../browser/cms/useTextSelection';
 
 export const InputFieldWithBrowser = ({
   label,
@@ -17,28 +18,8 @@ export const InputFieldWithBrowser = ({
   options
 }: InputFieldProps & { browsers: Array<BrowserType>; options?: TextBrowserFieldOptions }) => {
   const [open, setOpen] = useState(false);
-  const [savedSelection, setSavedSelection] = useState<{ start: number; end: number } | undefined>();
-
   const inputRef = useRef<HTMLInputElement>(null);
-  const handleTextSelection = () => {
-    if (inputRef.current) {
-      const selectionStart = inputRef.current.selectionStart ?? 0;
-      const selectionEnd = inputRef.current.selectionEnd ?? 0;
-      if (selectionStart !== selectionEnd) {
-        setSavedSelection({ start: selectionStart, end: selectionEnd });
-      } else {
-        setSavedSelection(undefined);
-      }
-    }
-  };
-
-  const getSelectedText = () => {
-    if (inputRef.current && savedSelection) {
-      const text = inputRef.current.value.substring(savedSelection.start, savedSelection.end);
-      return text;
-    }
-    return '';
-  };
+  const { handleTextSelection, showQuickFix, getSelectedText, selection } = useTextSelection(inputRef);
 
   return (
     <Dialog open={open} onOpenChange={setOpen}>
@@ -48,12 +29,12 @@ export const InputFieldWithBrowser = ({
             ref={inputRef}
             value={value}
             onChange={e => onChange(e.target.value)}
-            onSelect={handleTextSelection}
+            onSelect={() => handleTextSelection()}
             onBlur={onBlur}
             placeholder={options?.placeholder}
           />
-          {browsers.some(b => b === 'CMS') && inputRef.current?.selectionStart !== inputRef.current?.selectionEnd && savedSelection && (
-            <AddCmsQuickActionPopover value={getSelectedText()} savedSelection={savedSelection} inputRef={inputRef} onChange={onChange} />
+          {showQuickFix() && selection && browsers.some(b => b === 'CMS') && (
+            <AddCmsQuickFixPopover value={getSelectedText()} selection={selection} inputRef={inputRef} onChange={onChange} />
           )}
           <DialogTrigger asChild>
             <Button icon={IvyIcons.ListSearch} aria-label='Browser' />

--- a/packages/editor/src/editor/sidebar/fields/TextareaField.tsx
+++ b/packages/editor/src/editor/sidebar/fields/TextareaField.tsx
@@ -1,7 +1,9 @@
 import { BasicField, Button, Dialog, DialogContent, DialogTrigger, Flex, Textarea, type MessageData } from '@axonivy/ui-components';
-import { useState } from 'react';
+import { useRef, useState } from 'react';
 import { IvyIcons } from '@axonivy/ui-icons';
 import { Browser } from '../../browser/Browser';
+import { AddCmsQuickFixPopover } from '../../browser/cms/AddCmsQuickFix';
+import useTextSelection from '../../browser/cms/useTextSelection';
 
 type TextareaFieldProps = {
   label: string;
@@ -12,14 +14,35 @@ type TextareaFieldProps = {
 
 export const TextareaField = ({ label, value, onChange, message }: TextareaFieldProps) => {
   const [open, setOpen] = useState(false);
+  const textAreaRef = useRef<HTMLTextAreaElement>(null);
+  const { handleTextSelection, showQuickFix, getSelectedText, selection } = useTextSelection(textAreaRef);
+
   return (
     <Dialog open={open} onOpenChange={setOpen}>
       <BasicField label={label} message={message}>
         <Flex direction='row'>
-          <Textarea value={value} onChange={e => onChange(e.target.value)} autoResize={true} />
-          <DialogTrigger asChild style={{ marginLeft: '-25px', marginTop: '8px' }}>
-            <Button icon={IvyIcons.ListSearch} aria-label='Browser' />
-          </DialogTrigger>
+          <Textarea
+            value={value}
+            onChange={e => onChange(e.target.value)}
+            autoResize={true}
+            ref={textAreaRef}
+            onSelect={() => handleTextSelection()}
+          />
+          <Flex
+            direction='row'
+            style={{
+              marginLeft: showQuickFix() && selection ? '-49px' : '-25px',
+              marginTop: '8px'
+            }}
+            gap={1}
+          >
+            {showQuickFix() && selection && (
+              <AddCmsQuickFixPopover value={getSelectedText()} selection={selection} inputRef={textAreaRef} onChange={onChange} />
+            )}
+            <DialogTrigger asChild>
+              <Button icon={IvyIcons.ListSearch} aria-label='Browser' />
+            </DialogTrigger>
+          </Flex>
         </Flex>
       </BasicField>
       <DialogContent style={{ height: '80vh' }}>

--- a/playwright/tests/integration/properties/input.spec.ts
+++ b/playwright/tests/integration/properties/input.spec.ts
@@ -50,7 +50,7 @@ test('id', async ({ page }) => {
   await id.expectEmpty();
 });
 
-test('cmsQuickaction', async ({ page }) => {
+test('cmsQuickfix', async ({ page }) => {
   const editor = await FormEditor.openMock(page);
   await editor.canvas.blockByNth(0).inscribe();
   await editor.inscription.expectHeader('Input');
@@ -60,5 +60,5 @@ test('cmsQuickaction', async ({ page }) => {
 
   await label.expectValue('Firstname');
   await label.selectText();
-  await label.openQuickaction();
+  await label.openQuickfix();
 });

--- a/playwright/tests/page-objects/inscription.ts
+++ b/playwright/tests/page-objects/inscription.ts
@@ -193,14 +193,14 @@ export class Input {
     await this.locator.dblclick();
   }
 
-  async openQuickaction() {
-    await this.page.getByRole('button', { name: 'CMS-Quickaction' }).click();
+  async openQuickfix() {
+    await this.page.getByRole('button', { name: 'CMS-Quickfix' }).click();
 
     const popover = this.page.locator('[role="dialog"][data-state="open"]').nth(1);
     await expect(popover).toBeVisible();
 
-    const localButton = popover.getByRole('button', { name: 'CMS-Quickaction-local' });
-    const globalButton = popover.getByRole('button', { name: 'CMS-Quickaction-global' });
+    const localButton = popover.getByRole('button', { name: 'CMS-Quickfix-local' });
+    const globalButton = popover.getByRole('button', { name: 'CMS-Quickfix-global' });
 
     await expect(localButton).toBeVisible();
     await expect(globalButton).toBeVisible();


### PR DESCRIPTION
After discussing with Bruno, I have now incorporated the following feedback:
- Added the word "CMS-Object" to the CMS Quick Action button to help the user better understand the context.
- Added the CMS Quick Action to the "Content" property (Textarea) of the Text Component as well.
- The CMS Quick Action is now only displayed if the selection does not consist solely of whitespaces, does not contain #{}, and is not surrounded by #{ }.
- I also added some tests for the addCmsQuickAction-utils

![grafik](https://github.com/user-attachments/assets/8e28fbb8-cfb0-4c73-af59-90da853cd622)
