### PR TITLE
Fix badge styles in table

### DIFF
--- a/packages/editor/src/editor/sidebar/fields/table-field/TableField.css
+++ b/packages/editor/src/editor/sidebar/fields/table-field/TableField.css
@@ -11,6 +11,11 @@
         border: none;
         background-color: unset;
       }
+      .badge-field output {
+        background-color: inherit;
+        color: inherit;
+        border: none;
+      }
     }
     .ui-fieldset {
       gap: 0;


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/633c0a21-8625-44a9-b96d-ec7ea4dce755)

instead of:
![image](https://github.com/user-attachments/assets/1fee442e-aee4-4c1c-8055-11b4d9673d98)
