### PR TITLE
Remove badges from simple inputs

### DIFF
--- a/packages/editor/src/editor/sidebar/fields/InputField.tsx
+++ b/packages/editor/src/editor/sidebar/fields/InputField.tsx
@@ -1,7 +1,5 @@
-import { BasicField, Input, InputBadge, type MessageData } from '@axonivy/ui-components';
+import { BasicField, Input, type MessageData } from '@axonivy/ui-components';
 import type { TextFieldOptions } from '../../../types/config';
-import { useOnFocus } from '../../../context/useOnFocus';
-import { badgeProps } from '../../../utils/badge-properties';
 
 export type InputFieldProps = {
   label?: string;
@@ -11,21 +9,14 @@ export type InputFieldProps = {
   message?: MessageData;
 };
 
-export const InputField = ({ label, value, onChange, onBlur, message, options }: InputFieldProps & { options?: TextFieldOptions }) => {
-  const { isFocusWithin, focusWithinProps } = useOnFocus(value, onChange);
-  return (
-    <BasicField label={label} message={message} {...focusWithinProps} className='badge-field' tabIndex={0}>
-      {isFocusWithin ? (
-        <Input
-          value={value}
-          onChange={e => onChange(e.target.value)}
-          onBlur={onBlur}
-          placeholder={options?.placeholder}
-          disabled={options?.disabled}
-        />
-      ) : (
-        <InputBadge value={value ?? ''} badgeProps={badgeProps} style={{ height: 15 }} />
-      )}
-    </BasicField>
-  );
-};
+export const InputField = ({ label, value, onChange, onBlur, message, options }: InputFieldProps & { options?: TextFieldOptions }) => (
+  <BasicField label={label} message={message} className='badge-field' tabIndex={0}>
+    <Input
+      value={value}
+      onChange={e => onChange(e.target.value)}
+      onBlur={onBlur}
+      placeholder={options?.placeholder}
+      disabled={options?.disabled}
+    />
+  </BasicField>
+);

--- a/playwright/tests/integration/properties/combobox.spec.ts
+++ b/playwright/tests/integration/properties/combobox.spec.ts
@@ -11,8 +11,8 @@ test('default', async ({ page }) => {
   const value = general.input({ label: 'Value' });
   const options = properties.collapsible('Options');
   const complete = options.input({ label: 'Complete Method' });
-  const itemLabel = options.input({ label: 'Item Label' });
-  const itemValue = options.input({ label: 'Item Value' });
+  const itemLabel = options.input({ label: 'Item Label', type: 'text' });
+  const itemValue = options.input({ label: 'Item Value', type: 'text' });
   const button = options.checkbox({ label: 'Add Dropdown-Button to Combobox' });
   const behaviour = properties.behaviour();
 

--- a/playwright/tests/integration/properties/composite.spec.ts
+++ b/playwright/tests/integration/properties/composite.spec.ts
@@ -10,14 +10,13 @@ test('address', async ({ page }) => {
   await editor.inscription.expectHeader('Composite');
   const properties = editor.inscription.section('Properties');
   const general = properties.collapsible('General');
-  const composite = general.input({ label: 'Composite' });
+  const composite = general.input({ label: 'Composite', type: 'text' });
   const method = general.select({ label: 'Start Method' });
   const parameters = properties.collapsible('Parameters');
   const addressParam = parameters.input({ label: 'Address' });
   const labelParam = parameters.input({ label: 'Label' });
 
   await composite.expectValue('form.test.project.AddressComponent');
-  await composite.focus();
   await expect(composite.inputLocator).toBeDisabled();
   await method.expectValue('');
   await method.expectOptions(['start(Address)', 'empty()']);
@@ -50,13 +49,12 @@ test('person', async ({ page }) => {
   await editor.inscription.expectHeader('Composite');
   const properties = editor.inscription.section('Properties');
   const general = properties.collapsible('General');
-  const composite = general.input({ label: 'Composite' });
+  const composite = general.input({ label: 'Composite', type: 'text' });
   const method = general.select({ label: 'Start Method' });
   const parameters = properties.collapsible('Parameters');
   const person = parameters.input({ label: 'Person' });
 
   await composite.expectValue('form.test.project.PersonComponent');
-  await composite.focus();
   await expect(composite.inputLocator).toBeDisabled();
   await method.expectValue('');
   await method.expectOptions(['start(Person)']);

--- a/playwright/tests/integration/properties/datepicker.spec.ts
+++ b/playwright/tests/integration/properties/datepicker.spec.ts
@@ -9,9 +9,9 @@ test('default', async ({ page }) => {
   const general = properties.collapsible('General');
   const label = general.input({ label: 'Label' });
   const value = general.input({ label: 'Value' });
-  const datePattern = general.input({ label: 'Date Pattern' });
+  const datePattern = general.input({ label: 'Date Pattern', type: 'text' });
   const showTime = general.checkbox({ label: 'Show Time' });
-  const timePattern = general.input({ label: 'Time Pattern' });
+  const timePattern = general.input({ label: 'Time Pattern', type: 'text' });
   const behaviour = properties.behaviour();
 
   await label.expectValue('Date Picker');

--- a/playwright/tests/integration/properties/input.spec.ts
+++ b/playwright/tests/integration/properties/input.spec.ts
@@ -12,7 +12,7 @@ test('default', async ({ page }) => {
   const type = section.select({ label: 'Type' });
   const formattingSection = properties.collapsible('Formatting');
   const decimalPlaces = formattingSection.input({ label: 'Decimal Places', type: 'number' });
-  const symbol = formattingSection.input({ label: 'Symbol' });
+  const symbol = formattingSection.input({ label: 'Symbol', type: 'text' });
   const symbolPosition = formattingSection.select({ label: 'Symbol Position' });
   const behaviour = properties.behaviour();
 
@@ -35,7 +35,7 @@ test('default', async ({ page }) => {
   await value.expectValue('New Value');
   await type.expectValue('Number');
   await decimalPlaces.expectValue('2');
-  await symbol.expectValue('CHF');
+  await symbol.expectValue('CHF ');
   await symbolPosition.expectValue('Prefix');
   await behaviour.expectRequired();
 });
@@ -45,7 +45,7 @@ test('id', async ({ page }) => {
   await editor.canvas.blockByNth(0).inscribe();
   const properties = editor.inscription.section('Properties');
   const section = properties.collapsible('General');
-  const id = section.input({ label: 'Id', type: 'id' });
+  const id = section.input({ label: 'Id', type: 'text' });
   await expect(id.inputLocator).toHaveAttribute('placeholder', 'Input1');
   await id.expectEmpty();
 });

--- a/playwright/tests/integration/properties/link.spec.ts
+++ b/playwright/tests/integration/properties/link.spec.ts
@@ -8,7 +8,7 @@ test('default', async ({ page }) => {
   const properties = editor.inscription.section('Properties');
   const general = properties.collapsible('General');
   const name = general.input({ label: 'Name' });
-  const href = general.input({ label: 'Href' });
+  const href = general.input({ label: 'Href', type: 'text' });
   const behaviour = properties.behaviour();
 
   await name.expectValue('link');

--- a/playwright/tests/page-objects/inscription.ts
+++ b/playwright/tests/page-objects/inscription.ts
@@ -95,7 +95,7 @@ export class Collapsible {
     return new Select(this.page, this.content, options);
   }
 
-  input(options?: { label?: string; nth?: number; type?: 'number' | 'id' }) {
+  input(options?: { label?: string; nth?: number; type?: 'text' | 'number' }) {
     return new Input(this.page, this.content, options);
   }
 
@@ -157,7 +157,7 @@ export class Input {
   constructor(
     readonly page: Page,
     readonly parentLocator: Locator,
-    options?: { label?: string; nth?: number; type?: 'number' | 'id' }
+    options?: { label?: string; nth?: number; type?: 'text' | 'number' }
   ) {
     const role = options?.type === 'number' ? 'spinbutton' : 'textbox';
     const badgeLocator = parentLocator.locator('.badge-field');


### PR DESCRIPTION
I think simple input fields make no sense to have this badge component. If no browser is supported we also don't expect a el expression.

E.g. the name field of a composite is readonly and will not support el expressions:
![Screen Recording 2024-12-06 at 14 06 44](https://github.com/user-attachments/assets/fb2b407b-6d53-4161-ba7e-063095d85339)

Other solution would be to add a new field type or only remove it if the field is disabled (but I think this is not good).