### PR TITLE
Fix DataTableColumn drag and drop

### DIFF
--- a/packages/editor/src/editor/canvas/ComponentBlock.tsx
+++ b/packages/editor/src/editor/canvas/ComponentBlock.tsx
@@ -20,7 +20,7 @@ type ComponentBlockProps = Omit<DropZoneProps, 'id'> & {
 };
 
 export const ComponentBlock = ({ component, preId, ...props }: ComponentBlockProps) => (
-  <DropZone id={component.cid} preId={preId} {...props}>
+  <DropZone id={component.cid} type={component.type} preId={preId} {...props}>
     <Draggable config={componentByName(component.type)} data={component} />
   </DropZone>
 );

--- a/packages/editor/src/editor/canvas/DropZone.tsx
+++ b/packages/editor/src/editor/canvas/DropZone.tsx
@@ -3,16 +3,17 @@ import './DropZone.css';
 import type { ComponentProps } from 'react';
 import { isDropZoneDisabled } from './drag-data';
 import { cn } from '@axonivy/ui-components';
+import type { ComponentType } from '@axonivy/form-editor-protocol';
 
 export type DropZoneProps = ComponentProps<'div'> & {
   id: string;
+  type?: ComponentType;
   preId?: string;
-  dragHint?: boolean;
 };
 
-export const DropZone = ({ id, preId, className, children }: DropZoneProps) => {
+export const DropZone = ({ id, type, preId, className, children }: DropZoneProps) => {
   const dnd = useDndContext();
-  const { isOver, setNodeRef } = useDroppable({ id, disabled: isDropZoneDisabled(id, dnd.active, preId) });
+  const { isOver, setNodeRef } = useDroppable({ id, disabled: isDropZoneDisabled(id, type, dnd.active, preId) });
   return (
     <div ref={setNodeRef} className={cn('drop-zone', isOver && 'is-drop-target', className)}>
       <div className='drop-zone-block' />


### PR DESCRIPTION
I think this got broken with the id changes. Before the Id started with DataTableColumn, but this is not sure because the id is only needed to be unique but can be fully custom. We should only work with the type for such things.