### PR TITLE
XIVY-15526 remove cmsBadge prefix

### DIFF
--- a/packages/editor/src/utils/badge-properties.test.tsx
+++ b/packages/editor/src/utils/badge-properties.test.tsx
@@ -11,7 +11,7 @@ describe('createBadges', () => {
     render(<InputBadge badgeProps={badgeProps} value={inputValues} className='badge-output' />);
     const testDataBadge = screen.getByText('testData');
     const logicBadge = screen.getByText('testLogic');
-    const cmsBadge = screen.getByText('.../cssIcon');
+    const cmsBadge = screen.getByText('cssIcon');
     const expBadge = screen.getByText('el.expression');
 
     expect(testDataBadge).toBeVisible();
@@ -21,7 +21,7 @@ describe('createBadges', () => {
 
     expect(testDataBadge).toHaveTextContent('testData');
     expect(logicBadge).toHaveTextContent('testLogic');
-    expect(cmsBadge).toHaveTextContent('.../cssIcon');
+    expect(cmsBadge).toHaveTextContent('cssIcon');
     expect(expBadge).toHaveTextContent('el.expression');
 
     expect(testDataBadge?.querySelector('i.ivy-attribute')).toBeVisible();

--- a/packages/editor/src/utils/badge-properties.tsx
+++ b/packages/editor/src/utils/badge-properties.tsx
@@ -5,7 +5,7 @@ import { CmsTooltip } from './CmsTooltip';
 const badgePropertyCMS: BadgeType = {
   regex: /#{\s*ivy.cms.co[^}]+}/,
   icon: IvyIcons.Cms,
-  badgeTextGen: (text: string) => '...' + text.replaceAll(/#{\s*ivy.cms.co\(['"]|.*(?=\/)|['"]\)\s*}/g, ''),
+  badgeTextGen: (text: string) => text.replaceAll(/#{\s*ivy.cms.co\(['"]|.*(?=\/)\/|['"]\)\s*}/g, ''),
   tooltip: (text: string) => <CmsTooltip text={text} />
 };
 


### PR DESCRIPTION
- removes cms-badge prefix ".../" as it is deemed not needed with tooltip
![image](https://github.com/user-attachments/assets/b1f0e500-b514-4dcd-acdf-c3485bb52941)
