### PR TITLE
XIVY-15581 Remove type filter from attribute browser

### DIFF
--- a/packages/editor/src/components/blocks/base.tsx
+++ b/packages/editor/src/components/blocks/base.tsx
@@ -85,7 +85,7 @@ export const selectItemsComponentFields: Fields<SelectItemsProps> = {
     label: 'List of Objects',
     type: 'textBrowser',
     browsers: ['ATTRIBUTE'],
-    options: { onlyTypesOf: 'List<', placeholder: 'e.g. #{data.dynamicList}' }
+    options: { typeHint: 'List', placeholder: 'e.g. #{data.dynamicList}' }
   },
   dynamicItemsLabel: {
     subsection: 'Dynamic Options',

--- a/packages/editor/src/components/blocks/composite/fields/Parameters.tsx
+++ b/packages/editor/src/components/blocks/composite/fields/Parameters.tsx
@@ -58,7 +58,7 @@ const ParameterInput = ({ value, onChange, name, description, type, validationPa
       onChange={change => updateValue(name, change)}
       browsers={['ATTRIBUTE']}
       message={message ?? { variant: 'description', message: description }}
-      options={{ onlyTypesOf: type }}
+      options={{ typeHint: type }}
     />
   );
 };

--- a/packages/editor/src/components/blocks/datatable/DataTable.tsx
+++ b/packages/editor/src/components/blocks/datatable/DataTable.tsx
@@ -43,7 +43,7 @@ export const DataTableComponent: ComponentConfig<DataTableProps> = {
       label: 'List of Objects',
       type: 'textBrowser',
       browsers: ['ATTRIBUTE'],
-      options: { onlyTypesOf: 'List<' }
+      options: { typeHint: 'List' }
     },
     components: { subsection: 'Columns', label: 'Object-Bound Columns', type: 'generic', render: () => <ColumnsCheckboxField /> },
     paginator: { subsection: 'Paginator', label: 'Enable Paginator', type: 'checkbox' },

--- a/packages/editor/src/components/blocks/datepicker/DatePicker.tsx
+++ b/packages/editor/src/components/blocks/datepicker/DatePicker.tsx
@@ -30,7 +30,7 @@ export const DatePickerComponent: ComponentConfig<DatePickerProps> = {
   fields: {
     ...baseComponentFields,
     label: { subsection: 'General', label: 'Label', type: 'textBrowser', browsers: ['CMS'] },
-    value: { subsection: 'General', label: 'Value', type: 'textBrowser', browsers: ['ATTRIBUTE'], options: { onlyTypesOf: 'Date' } },
+    value: { subsection: 'General', label: 'Value', type: 'textBrowser', browsers: ['ATTRIBUTE'], options: { typeHint: 'Date' } },
     datePattern: { subsection: 'General', label: 'Date Pattern', type: 'text', options: { placeholder: 'e.g. dd.MM.yyyy' } },
     showTime: { subsection: 'General', label: 'Show Time', type: 'checkbox' },
     timePattern: {

--- a/packages/editor/src/editor/browser/Browser.tsx
+++ b/packages/editor/src/editor/browser/Browser.tsx
@@ -10,7 +10,7 @@ type OnlyAttributeSelection = 'DYNAMICLIST' | 'COLUMN';
 export type BrowserType = 'ATTRIBUTE' | 'LOGIC' | 'CMS' | 'CONDITION';
 
 export type BrowserOptions = {
-  onlyTypesOf?: string;
+  typeHint?: string;
   onlyAttributes?: OnlyAttributeSelection;
   directApply?: boolean;
 };

--- a/packages/editor/src/editor/browser/data-class/variable-tree-data.test.ts
+++ b/packages/editor/src/editor/browser/data-class/variable-tree-data.test.ts
@@ -1,7 +1,7 @@
 import type { VariableInfo } from '@axonivy/form-editor-protocol';
 import type { BrowserNode } from '@axonivy/ui-components';
 import type { Row } from '@tanstack/react-table';
-import { findAttributesOfType, findVariablesOfType, fullVariablePath, rowToCreateData, variableTreeData } from './variable-tree-data';
+import { findAttributesOfType, fullVariablePath, rowToCreateData, variableTreeData } from './variable-tree-data';
 
 const variableInfo: VariableInfo = {
   variables: [
@@ -126,13 +126,6 @@ describe('variableTreeData', () => {
     expect(tree[0].children[0].children[0].isLoaded).toBeTruthy();
     expect(tree[0].children[0].children[0].children[0].isLoaded).toBeFalsy();
   });
-});
-
-test('findListVariable of endless', () => {
-  const list = findVariablesOfType(endlessParamInfo, 'List<');
-  expect(list.length).toEqual(1);
-  expect(list[0].value).toEqual('param.Endless.endlessList');
-  expect(list[0].info).toEqual('List<demo.Endless>');
 });
 
 test('findAttributesOfType of List<demo.Endless>', () => {

--- a/packages/editor/src/editor/browser/data-class/variable-tree-data.ts
+++ b/packages/editor/src/editor/browser/data-class/variable-tree-data.ts
@@ -73,44 +73,6 @@ export const rowToCreateData = (row: Row<BrowserNode>): CreateComponentData | un
   };
 };
 
-export const findVariablesOfType = (variableInfo: VariableInfo, type: string, maxDepth: number = 10): Array<BrowserNode<Variable>> => {
-  const result: Array<BrowserNode<Variable>> = [];
-  const visitedTypes = new Set<string>();
-
-  const traverse = (currentType: string, path: string[], depth: number): void => {
-    if (depth > maxDepth) return;
-
-    const variables = variableInfo.types[currentType];
-    if (!variables || visitedTypes.has(currentType)) return;
-
-    visitedTypes.add(currentType);
-
-    for (const variable of variables) {
-      const newPath = [...path, variable.attribute];
-      if (variable.type.includes(type)) {
-        result.push({
-          value: newPath.join('.'),
-          info: variable.type,
-          icon: IvyIcons.Attribute,
-          data: variable,
-          children: [],
-          isLoaded: true
-        });
-      } else {
-        traverse(variable.type, newPath, depth + 1);
-      }
-    }
-
-    visitedTypes.delete(currentType);
-  };
-
-  for (const rootVariable of variableInfo.variables) {
-    traverse(rootVariable.type, [rootVariable.attribute], 0);
-  }
-
-  return result;
-};
-
 export function findAttributesOfType(data: VariableInfo, variableName: string, maxDepth: number = 10): Array<BrowserNode<Variable>> {
   const nameToSearch = extractVariableName(variableName);
 

--- a/playwright/tests/integration/properties/composite.spec.ts
+++ b/playwright/tests/integration/properties/composite.spec.ts
@@ -77,11 +77,13 @@ test('parameters browser', async ({ page }) => {
   const person = parameters.input({ label: 'Person' });
 
   let browser = await person.openBrowser();
-  await browser.expectEntries(['data.person']);
+  await expect(browser.view).toContainText(`Type 'form.test.project.Person' defined by the input field`);
+  await browser.expectEntries(['data', 'address', 'age', 'name', 'person']);
   await browser.close();
 
   await editor.canvas.blockByText('AddressComponent').block.dblclick({ position: { x: 10, y: 10 } });
   const address = parameters.input({ label: 'Address' });
   browser = await address.openBrowser();
-  await browser.expectEntries(['data.address', 'data.person.billingAddress', 'data.person.deliveryAddress']);
+  await expect(browser.view).toContainText(`Type 'form.test.project.Address' defined by the input field`);
+  await browser.expectEntries(['data', 'address', 'age', 'name', 'person']);
 });


### PR DESCRIPTION
Even if this feature was once good ment, it has many false positives:
- requested type `java.lang.Integer`, valid types `Integer`, `Number`, also things like strings etc seems to work
- requested type `String`, valid types `Number`, `Boolean`, etc.

I replaced it with a simple type hint.
![image](https://github.com/user-attachments/assets/5a90f305-8f9c-4fec-88c7-ee191a49096a)
