### PR TITLE
XIVY-15631 Copy paste elements > R12

### DIFF
--- a/packages/editor/src/data/data.test.ts
+++ b/packages/editor/src/data/data.test.ts
@@ -5,7 +5,8 @@ import {
   type LayoutConfig,
   type DataTable,
   type ConfigData,
-  type DataTableColumnComponent
+  type DataTableColumnComponent,
+  type TableConfig
 } from '@axonivy/form-editor-protocol';
 import { createInitForm, creationTargetId, DELETE_DROPZONE_ID, findComponentElement, findParentTableComponent, modifyData } from './data';
 import type { DeepPartial } from '../types/types';
@@ -156,6 +157,16 @@ describe('modifyData', () => {
       expectOrder(data, ['1', '2', '3', 'input54', '4', '5']);
     });
 
+    test('paste datatable column', () => {
+      // paste a datatable column acts always as duplicate
+      const data = modifyData(tableData(), { type: 'paste', data: { id: '11', targetId: '1' } }).newData;
+      expect(data).not.toEqual(tableData());
+      expect(data.components).toHaveLength(1);
+      const component = data.components.find(c => c.cid === '1') as TableConfig;
+      expect(component.config.components).toHaveLength(4);
+      expect(component.config.components[0].cid).toEqual('datatablecolumn14');
+    });
+
     test('duplicate deep', () => {
       const data = modifyData(filledData(), { type: 'paste', data: { id: '31' } }).newData;
       expect(data.components).toHaveLength(5);
@@ -174,6 +185,17 @@ describe('modifyData', () => {
       expect((component.config.components[0].config as ConfigData).content).toEqual('Hello');
       expect(component.config.components[1].cid).toEqual('button56');
       expect(component.config.components[2].cid).toEqual('input57');
+    });
+
+    test('duplicate table', () => {
+      const data = modifyData(tableData(), { type: 'paste', data: { id: '1' } }).newData;
+      expect(data.components).toHaveLength(2);
+      const component = data.components.find(c => c.cid === 'datatable14') as TableConfig;
+      expect(component.config.components).toHaveLength(3);
+      expect(component.config.components[0].cid).toEqual('datatablecolumn15');
+      expect(component.config.components[0].config.value).toEqual('Hello');
+      expect(component.config.components[1].cid).toEqual('datatablecolumn16');
+      expect(component.config.components[2].cid).toEqual('datatablecolumn17');
     });
   });
 
@@ -343,6 +365,25 @@ const filledData = () => {
   expectOrderDeep(filledData, '4', ['41', '42', '43']);
   expectOrderDeep(filledData, '5', ['51', '52', '53']);
   return filledData;
+};
+
+const tableData = () => {
+  const prefilledData: DeepPartial<FormData> = {
+    components: [
+      {
+        cid: '1',
+        type: 'DataTable',
+        config: {
+          components: [
+            { cid: '11', type: 'DataTableColumn', config: { value: 'Hello' } },
+            { cid: '12', type: 'DataTableColumn', config: {} },
+            { cid: '13', type: 'DataTableColumn', config: {} }
+          ]
+        }
+      }
+    ]
+  };
+  return prefilledData as FormData;
 };
 
 const expectOrder = (data: FormData, order: string[]) => {

--- a/packages/editor/src/data/data.test.ts
+++ b/packages/editor/src/data/data.test.ts
@@ -141,21 +141,39 @@ describe('modifyData', () => {
     expect(data.components[0].type).to.equals('Input');
   });
 
-  describe('duplicate', () => {
+  describe('paste', () => {
     test('duplicate', () => {
-      const data = modifyData(filledData(), { type: 'duplicate', data: { id: '1' } }).newData;
+      const data = modifyData(filledData(), { type: 'paste', data: { id: '1' } }).newData;
       expect(data).not.toEqual(filledData());
       expect(data.components).toHaveLength(6);
-      expect(data.components[0].cid).toEqual('input54');
+      expectOrder(data, ['input54', '1', '2', '3', '4', '5']);
+    });
+
+    test('paste', () => {
+      const data = modifyData(filledData(), { type: 'paste', data: { id: '1', targetId: '4' } }).newData;
+      expect(data).not.toEqual(filledData());
+      expect(data.components).toHaveLength(6);
+      expectOrder(data, ['1', '2', '3', 'input54', '4', '5']);
     });
 
     test('duplicate deep', () => {
-      const data = modifyData(filledData(), { type: 'duplicate', data: { id: '31' } }).newData;
+      const data = modifyData(filledData(), { type: 'paste', data: { id: '31' } }).newData;
       expect(data.components).toHaveLength(5);
       const component = data.components.find(c => c.cid === '3') as LayoutConfig;
       expect(component.config.components).toHaveLength(4);
       expect(component.config.components[0].cid).toEqual('text54');
       expect((component.config.components[0].config as ConfigData).content).toEqual('Hello');
+    });
+
+    test('duplicate layout', () => {
+      const data = modifyData(filledData(), { type: 'paste', data: { id: '3' } }).newData;
+      expect(data.components).toHaveLength(6);
+      const component = data.components.find(c => c.cid === 'layout54') as LayoutConfig;
+      expect(component.config.components).toHaveLength(3);
+      expect(component.config.components[0].cid).toEqual('text55');
+      expect((component.config.components[0].config as ConfigData).content).toEqual('Hello');
+      expect(component.config.components[1].cid).toEqual('button56');
+      expect(component.config.components[2].cid).toEqual('input57');
     });
   });
 

--- a/packages/editor/src/data/data.ts
+++ b/packages/editor/src/data/data.ts
@@ -174,7 +174,11 @@ const allCids = (components: Array<ComponentData>) => {
 const pasteComponent = (data: FormData, id: string, targetId?: string) => {
   const newComponent = structuredClone(findComponentElement(data, id));
   if (newComponent) {
-    const added = addComponent(data.components, newComponent.element, targetId ?? id);
+    let copyTarget = targetId ?? id;
+    if (newComponent.element.type === 'DataTableColumn') {
+      copyTarget = id;
+    }
+    const added = addComponent(data.components, newComponent.element, copyTarget);
     defineNewCid(data.components, newComponent.element);
     return added;
   }
@@ -183,7 +187,7 @@ const pasteComponent = (data: FormData, id: string, targetId?: string) => {
 
 const defineNewCid = (components: Array<ComponentData>, component: ComponentData) => {
   component.cid = createId(components, component.type);
-  if (isStructure(component)) {
+  if (isStructure(component) || isTable(component)) {
     for (const child of component.config.components) {
       defineNewCid(components, child);
     }

--- a/playwright/tests/integration/canvas.spec.ts
+++ b/playwright/tests/integration/canvas.spec.ts
@@ -63,6 +63,30 @@ test.describe('keyboard', () => {
     await page.keyboard.press('Delete');
     await canvas.expectFormOrder(['Lastname', 'Address']);
   });
+
+  test('undo/redo', async ({ page }) => {
+    const { canvas } = await FormEditor.openMock(page);
+    await canvas.expectFormOrder(['Firstname', 'Lastname', 'Address']);
+    await canvas.blockByText('Firstname').select();
+    await page.keyboard.press('ArrowDown');
+    await canvas.expectFormOrder(['Lastname', 'Firstname', 'Address']);
+
+    await page.keyboard.press('ControlOrMeta+z');
+    await canvas.expectFormOrder(['Firstname', 'Lastname', 'Address']);
+    await page.keyboard.press('ControlOrMeta+Shift+z');
+    await canvas.expectFormOrder(['Lastname', 'Firstname', 'Address']);
+  });
+
+  test('paste', async ({ page, browserName }) => {
+    test.skip(browserName === 'webkit', 'Was not able to make it work on webkit');
+    const { canvas } = await FormEditor.openMock(page);
+    await canvas.expectFormOrder(['Firstname', 'Lastname']);
+    await canvas.blockByText('Firstname').select();
+    await page.keyboard.press(`ControlOrMeta+c`);
+    await canvas.blockByText('Address').select();
+    await page.keyboard.press(`ControlOrMeta+v`);
+    await canvas.expectFormOrder(['Firstname', 'Lastname', 'Firstname']);
+  });
 });
 
 test.describe('quickbar', () => {


### PR DESCRIPTION
same as master https://github.com/axonivy/form-editor-client/pull/257 and https://github.com/axonivy/form-editor-client/pull/260

- Fix layout duplication by create new cids for child elements
- Copy / Paste elements to selected new target
- Generate new cid's for columns in copied data table
- Copy paste columns is the same as duplicate, to ensure a column is not copied outside of a table