### PR TITLE
XIVY-15035 Multiple impr. around DataTableActionButtons

### DIFF
--- a/packages/editor/src/components/blocks/button/Button.tsx
+++ b/packages/editor/src/components/blocks/button/Button.tsx
@@ -36,7 +36,13 @@ export const ButtonComponent: ComponentConfig<ButtonProps> = {
   fields: {
     ...baseComponentFields,
     name: { subsection: 'General', label: 'Name', type: 'textBrowser', browsers: ['CMS'] },
-    action: { subsection: 'General', label: 'Action', type: 'textBrowser', browsers: ['LOGIC'] },
+    action: {
+      subsection: 'General',
+      label: 'Action',
+      type: 'textBrowser',
+      browsers: ['LOGIC', 'ATTRIBUTE'],
+      options: { overrideSelection: true }
+    },
     variant: { subsection: 'General', label: 'Variant', type: 'select', options: variantOptions },
     icon: { subsection: 'General', label: 'Icon', type: 'hidden' },
     processOnlySelf: { subsection: 'Behaviour', type: 'hidden' },

--- a/packages/editor/src/components/blocks/datatable/DataTable.css
+++ b/packages/editor/src/components/blocks/datatable/DataTable.css
@@ -5,7 +5,7 @@
 }
 
 .block-table__columns {
-  width: 100%;
+  overflow-x: auto;
   > div {
     flex: 1 1 auto;
   }

--- a/packages/editor/src/components/blocks/layout/Layout.css
+++ b/packages/editor/src/components/blocks/layout/Layout.css
@@ -1,5 +1,6 @@
 .block-layout {
   gap: var(--size-4);
+  overflow-x: auto;
 }
 .block-layout.grid {
   display: grid;

--- a/packages/editor/src/data/data.test.ts
+++ b/packages/editor/src/data/data.test.ts
@@ -184,7 +184,18 @@ describe('modifyData', () => {
       expect(data.components).toHaveLength(1);
       const component = data.components.find(c => c.cid === '1') as TableConfig;
       expect(component.config.components).toHaveLength(4);
-      expect(component.config.components[0].cid).toEqual('datatablecolumn14');
+      expect(component.config.components[0].cid).toEqual('datatablecolumn15');
+    });
+
+    test('paste datatable action column', () => {
+      // paste a datatable column acts always as duplicate
+      const data = modifyData(tableData(), { type: 'paste', data: { id: '13', targetId: '1' } }).newData;
+      expect(data).not.toEqual(tableData());
+      expect(data.components).toHaveLength(1);
+      const component = data.components.find(c => c.cid === '1') as TableConfig;
+      expect(component.config.components).toHaveLength(4);
+      expect(component.config.components[2].config.components).toHaveLength(1);
+      expect(component.config.components[2].config.components[0].cid).toEqual('button16');
     });
 
     test('paste other things into datatable', () => {
@@ -220,18 +231,18 @@ describe('modifyData', () => {
     test('duplicate table', () => {
       const data = modifyData(tableData(), { type: 'paste', data: { id: '1' } }).newData;
       expect(data.components).toHaveLength(2);
-      const component = data.components.find(c => c.cid === 'datatable14') as TableConfig;
+      const component = data.components.find(c => c.cid === 'datatable15') as TableConfig;
       expect(component.config.components).toHaveLength(3);
-      expect(component.config.components[0].cid).toEqual('datatablecolumn15');
+      expect(component.config.components[0].cid).toEqual('datatablecolumn16');
       expect(component.config.components[0].config.value).toEqual('Hello');
-      expect(component.config.components[1].cid).toEqual('datatablecolumn16');
-      expect(component.config.components[2].cid).toEqual('datatablecolumn17');
+      expect(component.config.components[1].cid).toEqual('datatablecolumn17');
+      expect(component.config.components[2].cid).toEqual('datatablecolumn18');
     });
 
     test('duplicate table column', () => {
       const data = modifyData(tableData(), { type: 'paste', data: { id: '11' } }).newData;
       expectOrder(data, ['1']);
-      expectOrderDeep(data, '1', ['datatablecolumn14', '11', '12', '13']);
+      expectOrderDeep(data, '1', ['datatablecolumn15', '11', '12', '13']);
     });
   });
 
@@ -431,7 +442,7 @@ const tableData = () => {
           components: [
             { cid: '11', type: 'DataTableColumn', config: { value: 'Hello' } },
             { cid: '12', type: 'DataTableColumn', config: {} },
-            { cid: '13', type: 'DataTableColumn', config: {} }
+            { cid: '13', type: 'DataTableColumn', config: { components: [{ cid: '14', type: 'Button', config: {} }] } }
           ]
         }
       }

--- a/packages/editor/src/data/data.ts
+++ b/packages/editor/src/data/data.ts
@@ -92,9 +92,9 @@ const findDataTableColumnComponent = (data: Array<ComponentData>, id: string) =>
   return undefined;
 };
 
-export const isActionButtonComponent = (data: Array<ComponentData>, elementCid: string) => {
+export const getParentColumnComponent = (data: Array<ComponentData>, elementCid: string) => {
   const find = findComponentDeep(data, elementCid);
-  return find?.parent?.type === 'DataTableColumn';
+  return { isDataTableColumnComponent: find?.parent?.type === 'DataTableColumn', component: find?.parent };
 };
 
 export const findParentTableComponent = (data: Array<ComponentData>, element: ComponentData | undefined): DataTable | undefined => {
@@ -225,7 +225,7 @@ const pasteComponent = (data: FormData, id: string, targetId?: string) => {
 
 const defineNewCid = (components: Array<ComponentData>, component: ComponentData) => {
   component.cid = createId(components, component.type);
-  if (isStructure(component) || isTable(component)) {
+  if (isStructure(component) || isTable(component) || isColumn(component)) {
     for (const child of component.config.components) {
       defineNewCid(components, child);
     }

--- a/packages/editor/src/editor/browser/data-class/useAttributeBrowser.tsx
+++ b/packages/editor/src/editor/browser/data-class/useAttributeBrowser.tsx
@@ -4,7 +4,7 @@ import { useMeta } from '../../../context/useMeta';
 import { useCallback, useEffect, useState } from 'react';
 import type { ConfigData, Variable } from '@axonivy/form-editor-protocol';
 import { useAppContext } from '../../../context/AppContext';
-import { findParentTableComponent, useData } from '../../../data/data';
+import { findParentTableComponent, getParentColumnComponent, useData } from '../../../data/data';
 import type { BrowserOptions } from '../Browser';
 import { findAttributesOfType, variableTreeData, fullVariablePath } from './variable-tree-data';
 
@@ -19,10 +19,19 @@ export const useAttributeBrowser = (options?: BrowserOptions): Browser => {
 
   useEffect(() => {
     if (options?.onlyAttributes === 'DYNAMICLIST') {
-      setTree(findAttributesOfType(variableInfo, dynamicList));
+      setTree(findAttributesOfType(variableInfo, dynamicList, 10, 'Dynamic Object'));
     } else if (options?.onlyAttributes === 'COLUMN') {
       const parentTableComponent = findParentTableComponent(data.components, element);
-      setTree(findAttributesOfType(variableInfo, parentTableComponent ? parentTableComponent.value : ''));
+      setTree(findAttributesOfType(variableInfo, parentTableComponent ? parentTableComponent.value : '', 10, 'Row-Object'));
+    } else if (element && getParentColumnComponent(data.components, element.cid).isDataTableColumnComponent) {
+      const parentTableComponent = findParentTableComponent(
+        data.components,
+        getParentColumnComponent(data.components, element.cid).component
+      );
+      setTree([
+        ...findAttributesOfType(variableInfo, parentTableComponent ? parentTableComponent.value : '', 10, 'Row-Object'),
+        ...variableTreeData().of(variableInfo)
+      ]);
     } else {
       setTree(variableTreeData().of(variableInfo));
     }

--- a/packages/editor/src/editor/browser/data-class/variable-tree-data.test.ts
+++ b/packages/editor/src/editor/browser/data-class/variable-tree-data.test.ts
@@ -131,7 +131,7 @@ describe('variableTreeData', () => {
 test('findAttributesOfType of List<demo.Endless>', () => {
   const list = findAttributesOfType(endlessParamInfo, 'param.Endless.endlessList');
   expect(list.length).toEqual(1);
-  expect(list[0].value).toEqual('Use entire Object');
+  expect(list[0].value).toEqual('variable');
   expect(list[0].info).toEqual('demo.Endless');
   expect(list[0].children[0].value).toEqual('endless');
   expect(list[0].children[0].info).toEqual('demo.Endless');

--- a/packages/editor/src/editor/browser/data-class/variable-tree-data.ts
+++ b/packages/editor/src/editor/browser/data-class/variable-tree-data.ts
@@ -73,7 +73,12 @@ export const rowToCreateData = (row: Row<BrowserNode>): CreateComponentData | un
   };
 };
 
-export function findAttributesOfType(data: VariableInfo, variableName: string, maxDepth: number = 10): Array<BrowserNode<Variable>> {
+export function findAttributesOfType(
+  data: VariableInfo,
+  variableName: string,
+  maxDepth: number = 10,
+  additionalInfo?: string
+): Array<BrowserNode<Variable>> {
   const nameToSearch = extractVariableName(variableName);
 
   for (const attributes of Object.values(data.types)) {
@@ -84,8 +89,8 @@ export function findAttributesOfType(data: VariableInfo, variableName: string, m
 
       return [
         {
-          value: 'Use entire Object',
-          info: extractedType,
+          value: 'variable',
+          info: `${additionalInfo ? additionalInfo + ' - ' : ''}${extractedType}`,
           icon: IvyIcons.Attribute,
           data: { attribute: nameToSearch, description: '', simpleType: extractedType, type: extractedType },
           children,

--- a/packages/editor/src/editor/canvas/ComponentBlock.tsx
+++ b/packages/editor/src/editor/canvas/ComponentBlock.tsx
@@ -6,7 +6,7 @@ import { useDraggable } from '@dnd-kit/core';
 import {
   COLUMN_DROPZONE_ID_PREFIX,
   creationTargetId,
-  isActionButtonComponent,
+  getParentColumnComponent,
   modifyData,
   TABLE_DROPZONE_ID_PREFIX,
   useData
@@ -172,10 +172,15 @@ const Draggable = ({ config, data }: DraggableProps) => {
         deleteAction={config.quickActions.includes('DELETE') ? deleteElement : undefined}
         duplicateAction={config.quickActions.includes('DUPLICATE') ? duplicateElement : undefined}
         createAction={
-          !isActionButtonComponent(formData.components, data.cid) && config.quickActions.includes('CREATE') ? createElement : undefined
+          !getParentColumnComponent(formData.components, data.cid).isDataTableColumnComponent && config.quickActions.includes('CREATE')
+            ? createElement
+            : undefined
         }
         createFromDataAction={
-          !isActionButtonComponent(formData.components, data.cid) && config.quickActions.includes('CREATEFROMDATA') ? data.cid : undefined
+          !getParentColumnComponent(formData.components, data.cid).isDataTableColumnComponent &&
+          config.quickActions.includes('CREATEFROMDATA')
+            ? data.cid
+            : undefined
         }
         createColumnAction={config.quickActions.includes('CREATECOLUMN') ? createColumn : undefined}
         createActionColumnAction={config.quickActions.includes('CREATEACTIONCOLUMN') ? createActionColumn : undefined}

--- a/packages/editor/src/editor/canvas/DropZone.css
+++ b/packages/editor/src/editor/canvas/DropZone.css
@@ -1,7 +1,7 @@
 .drop-zone {
   display: flex;
   flex-direction: column;
-  min-width: 0;
+  min-width: auto;
   &.is-drop-target {
     &:has(.drag-hint) .drop-zone-block {
       height: 0;

--- a/packages/editor/src/editor/canvas/drag-data.ts
+++ b/packages/editor/src/editor/canvas/drag-data.ts
@@ -2,7 +2,7 @@ import { isColumn, isStructure, isTable, type Component, type ComponentData, typ
 import type { Active } from '@dnd-kit/core';
 import {
   COLUMN_DROPZONE_ID_PREFIX,
-  isActionButtonComponent,
+  getParentColumnComponent,
   STRUCTURE_DROPZONE_ID_PREFIX,
   TABLE_DROPZONE_ID_PREFIX
 } from '../../data/data';
@@ -57,7 +57,8 @@ export const isDropZoneDisabled = (
   const data = active.data.current;
 
   if (
-    (dropId.startsWith(COLUMN_DROPZONE_ID_PREFIX) || (components && isActionButtonComponent(components, dropId))) &&
+    (dropId.startsWith(COLUMN_DROPZONE_ID_PREFIX) ||
+      (components && getParentColumnComponent(components, dropId).isDataTableColumnComponent)) &&
     data?.componentType !== 'Button' &&
     active.id !== 'Button'
   ) {

--- a/packages/editor/src/editor/sidebar/fields/InputFieldWithBrowser.tsx
+++ b/packages/editor/src/editor/sidebar/fields/InputFieldWithBrowser.tsx
@@ -20,6 +20,7 @@ export const InputFieldWithBrowser = ({
   options
 }: InputFieldProps & { browsers: Array<BrowserType>; options?: TextBrowserFieldOptions }) => {
   const [open, setOpen] = useState(false);
+
   const inputRef = useRef<HTMLInputElement>(null);
   const { isFocusWithin, focusWithinProps } = useOnFocus(value, onChange);
   const { handleTextSelection, showQuickFix, getSelectedText, selection } = useTextSelection(inputRef);
@@ -60,7 +61,14 @@ export const InputFieldWithBrowser = ({
         style={{ height: '80vh' }}
         onCloseAutoFocus={browsers.includes('LOGIC') ? e => focusBracketContent(e, value, inputRef.current) : undefined}
       >
-        <Browser activeBrowsers={browsers} close={() => setOpen(false)} value={value} onChange={onChange} options={options} />
+        <Browser
+          activeBrowsers={browsers}
+          close={() => setOpen(false)}
+          value={value}
+          onChange={onChange}
+          options={options}
+          selection={selection}
+        />
       </DialogContent>
     </Dialog>
   );


### PR DESCRIPTION
- Add Attribute-browser to Action-Button
- If text is selected Attr.-Browser replace selection
- Add scrollbar to DataTable if to many columns


Regarding the attribute browser in the action of the button, I have now solved it as follows:
- If something is selected, this selection is replaced with the content of the attribute browser
- If nothing is selected, the content is added to the back (you could possibly make it even smarter by searching for brackets and adding the content to the brackets, for example)
- Something that I still find a little impractical from a UX point of view is that after something has been added via the logic browser, the badge are displayed, you have to click in the action field again, select something and only then can you select the row object via the attribute browser. This is quite difficult to improve because of the useFocusWithin hook/badge-logic. I also have the feeling (even if this means some effort) that it is more understandable from a low-coder point of view that you can assign the parameters to the correct data directly in the open logic browser via attributebrowser.

![actionButtons2222](https://github.com/user-attachments/assets/1793a560-10fb-4011-9c98-0cc005aa70a3)
