### PR TITLE
XIVY-16072 Add Type to Button-Component

### DIFF
--- a/packages/editor/src/components/blocks/button/Button.tsx
+++ b/packages/editor/src/components/blocks/button/Button.tsx
@@ -1,4 +1,4 @@
-import type { Button, ButtonVariant, Prettify } from '@axonivy/form-editor-protocol';
+import type { Button, ButtonVariant, ButtonType, Prettify } from '@axonivy/form-editor-protocol';
 import { DEFAULT_QUICK_ACTIONS, type ComponentConfig, type FieldOption, type UiComponentProps } from '../../../types/config';
 import './Button.css';
 import { baseComponentFields, defaultBaseComponent, defaultDisabledComponent, disabledComponentFields } from '../base';
@@ -14,10 +14,17 @@ const variantOptions: FieldOption<ButtonVariant>[] = [
   { label: 'Danger', value: 'DANGER' }
 ] as const;
 
+const typeOptions: FieldOption<ButtonType>[] = [
+  { label: 'Button', value: 'BUTTON' },
+  { label: 'Submit', value: 'SUBMIT' },
+  { label: 'Reset', value: 'RESET' }
+] as const;
+
 export const defaultButtonProps: Button = {
   name: 'Action',
   action: '',
   variant: 'PRIMARY',
+  type: 'BUTTON',
   icon: '',
   processOnlySelf: false,
   ...defaultDisabledComponent,
@@ -45,6 +52,7 @@ export const ButtonComponent: ComponentConfig<ButtonProps> = {
       options: { overrideSelection: true }
     },
     variant: { subsection: 'General', label: 'Variant', type: 'select', options: variantOptions },
+    type: { subsection: 'General', label: 'Type', type: 'select', options: typeOptions },
     icon: { subsection: 'General', label: 'Icon', type: 'generic', render: renderIconField },
     processOnlySelf: { subsection: 'Behaviour', type: 'hidden' },
     ...disabledComponentFields

--- a/packages/editor/src/components/blocks/button/Button.tsx
+++ b/packages/editor/src/components/blocks/button/Button.tsx
@@ -1,4 +1,4 @@
-import type { Button, ButtonVariant, ButtonType, Prettify } from '@axonivy/form-editor-protocol';
+import type { Button, ButtonVariant, Prettify } from '@axonivy/form-editor-protocol';
 import { DEFAULT_QUICK_ACTIONS, type ComponentConfig, type FieldOption, type UiComponentProps } from '../../../types/config';
 import './Button.css';
 import { baseComponentFields, defaultBaseComponent, defaultDisabledComponent, disabledComponentFields } from '../base';
@@ -12,12 +12,6 @@ const variantOptions: FieldOption<ButtonVariant>[] = [
   { label: 'Primary', value: 'PRIMARY' },
   { label: 'Secondary', value: 'SECONDARY' },
   { label: 'Danger', value: 'DANGER' }
-] as const;
-
-const typeOptions: FieldOption<ButtonType>[] = [
-  { label: 'Button', value: 'BUTTON' },
-  { label: 'Submit', value: 'SUBMIT' },
-  { label: 'Reset', value: 'RESET' }
 ] as const;
 
 export const defaultButtonProps: Button = {
@@ -52,7 +46,7 @@ export const ButtonComponent: ComponentConfig<ButtonProps> = {
       options: { overrideSelection: true }
     },
     variant: { subsection: 'General', label: 'Variant', type: 'select', options: variantOptions },
-    type: { subsection: 'General', label: 'Type', type: 'select', options: typeOptions },
+    type: { subsection: 'General', label: 'Type', type: 'hidden' },
     icon: { subsection: 'General', label: 'Icon', type: 'generic', render: renderIconField },
     processOnlySelf: { subsection: 'Behaviour', type: 'hidden' },
     ...disabledComponentFields

--- a/packages/editor/src/data/data.test.ts
+++ b/packages/editor/src/data/data.test.ts
@@ -292,7 +292,9 @@ describe('createInitForm', () => {
     expect(layout.type).toEqual('Layout');
     expect(layout.config.components).toHaveLength(2);
     expect((layout.config.components[0].config as ConfigData).action).toEqual('#{ivyWorkflowView.cancel()}');
+    expect((layout.config.components[0].config as ConfigData).type).toEqual('BUTTON');
     expect((layout.config.components[1].config as ConfigData).action).toEqual('#{logic.close}');
+    expect((layout.config.components[1].config as ConfigData).type).toEqual('SUBMIT');
   });
 });
 

--- a/packages/editor/src/data/data.ts
+++ b/packages/editor/src/data/data.ts
@@ -311,7 +311,7 @@ export const createInitForm = (
       type: 'add',
       data: {
         componentName: 'Button',
-        create: { label: 'Proceed', value: '#{logic.close}', defaultProps: { variant: 'PRIMARY' } },
+        create: { label: 'Proceed', value: '#{logic.close}', defaultProps: { variant: 'PRIMARY', type: 'SUBMIT' } },
         targetId: layoutId
       }
     }).newData;

--- a/packages/protocol/src/data/form.ts
+++ b/packages/protocol/src/data/form.ts
@@ -8,6 +8,7 @@
 
 export type CmsQuickactionCategory = ("global" | "local")
 export type ContentObjectType = "STRING" | "FILE" | "FOLDER";
+export type ButtonType = "SUBMIT" | "BUTTON" | "RESET";
 export type ButtonVariant = "PRIMARY" | "SECONDARY" | "DANGER";
 export type SymbolPosition = "p" | "s";
 export type InputType = "TEXT" | "EMAIL" | "PASSWORD" | "NUMBER";
@@ -149,6 +150,7 @@ export interface Button {
   mdSpan: string;
   name: string;
   processOnlySelf: boolean;
+  type: ButtonType;
   variant: ButtonVariant;
   visible: string;
 }

--- a/playwright/tests/integration/properties/button.spec.ts
+++ b/playwright/tests/integration/properties/button.spec.ts
@@ -9,17 +9,14 @@ test('default', async ({ page }) => {
   const section = properties.collapsible('General');
   const name = section.input({ label: 'Name' });
   const action = section.input({ label: 'Action' });
-  const type = section.select({ label: 'Type' });
   const variant = section.select({ label: 'Variant' });
   const behaviour = properties.behaviour();
 
   await name.expectValue('Action');
   await action.expectValue('');
-  await type.expectValue('Button');
   await variant.expectValue('Primary');
   await name.fill('Cancel');
   await action.fill('#{logic.close}');
-  await type.choose('Submit');
   await variant.choose('Secondary');
   await behaviour.fillDisable();
 
@@ -27,7 +24,6 @@ test('default', async ({ page }) => {
   await editor.canvas.blockByNth(0).inscribe();
   await name.expectValue('Cancel');
   await action.expectValue('close');
-  await type.expectValue('Submit');
   await variant.expectValue('Secondary');
   await behaviour.excpectDisabled();
 });

--- a/playwright/tests/integration/properties/button.spec.ts
+++ b/playwright/tests/integration/properties/button.spec.ts
@@ -9,14 +9,17 @@ test('default', async ({ page }) => {
   const section = properties.collapsible('General');
   const name = section.input({ label: 'Name' });
   const action = section.input({ label: 'Action' });
+  const type = section.select({ label: 'Type' });
   const variant = section.select({ label: 'Variant' });
   const behaviour = properties.behaviour();
 
   await name.expectValue('Action');
   await action.expectValue('');
+  await type.expectValue('Button');
   await variant.expectValue('Primary');
   await name.fill('Cancel');
   await action.fill('#{logic.close}');
+  await type.choose('Submit');
   await variant.choose('Secondary');
   await behaviour.fillDisable();
 
@@ -24,6 +27,7 @@ test('default', async ({ page }) => {
   await editor.canvas.blockByNth(0).inscribe();
   await name.expectValue('Cancel');
   await action.expectValue('close');
+  await type.expectValue('Submit');
   await variant.expectValue('Secondary');
   await behaviour.excpectDisabled();
 });


### PR DESCRIPTION
I added a type field to the button component, defaulting it to "button". For the cancel/proceed buttons, I set the proceed button's type to "submit" to ensure that pressing Enter in the form only triggers the "Proceed" button.
@ivy-lgi, @ivy-rew What do you think? Should I expose the type field in the properties (like I now have via the select) or keep it hidden from users, setting it only to "submit" for the auto-generated "Proceed" button?

![grafik](https://github.com/user-attachments/assets/3c21e3e6-227e-4af2-a1da-a11655d1a50b)

https://github.com/axonivy/core/pull/8023
 