### PR TITLE
XIVY-16035 Add Badges to Fieldset & Panel Titles analog other comp.

### DIFF
--- a/packages/editor/src/components/blocks/fieldset/Fieldset.tsx
+++ b/packages/editor/src/components/blocks/fieldset/Fieldset.tsx
@@ -5,7 +5,8 @@ import IconSvg from './Fieldset.svg?react';
 import { defaultBaseComponent, baseComponentFields, defaultVisibleComponent, visibleComponentField } from '../base';
 import { EmptyLayoutBlock } from '../../../editor/canvas/EmptyBlock';
 import './Fieldset.css';
-import { UiBlockHeader } from '../../UiBlockHeader';
+import { UiBadge, UiBlockHeader } from '../../UiBlockHeader';
+import { Flex } from '@axonivy/ui-components';
 
 type FieldsetProps = Prettify<Fieldset>;
 
@@ -44,8 +45,10 @@ const UiBlock = ({ id, components, legend, collapsible, collapsed, visible }: Ui
     <UiBlockHeader visible={visible} />
     <fieldset className={`${collapsible ? (collapsed ? 'collapsible default-collapsed' : 'collapsible') : ''}`}>
       <legend>
-        {collapsible ? (collapsed ? '+ ' : '- ') : ''}
-        {legend}
+        <Flex direction='row' alignItems='center' gap={1}>
+          {collapsible ? (collapsed ? '+' : '-') : ''}
+          <UiBadge value={legend} />
+        </Flex>
       </legend>
       {components.map((component, index) => (
         <ComponentBlock key={component.cid} component={component} preId={components[index - 1]?.cid} />

--- a/packages/editor/src/components/blocks/panel/Panel.tsx
+++ b/packages/editor/src/components/blocks/panel/Panel.tsx
@@ -7,7 +7,7 @@ import { IvyIcons } from '@axonivy/ui-icons';
 import { ComponentBlock } from '../../../editor/canvas/ComponentBlock';
 import { EmptyLayoutBlock } from '../../../editor/canvas/EmptyBlock';
 import './Panel.css';
-import { UiBlockHeaderVisiblePart } from '../../UiBlockHeader';
+import { UiBadge, UiBlockHeaderVisiblePart } from '../../UiBlockHeader';
 
 type PanelProps = Prettify<Panel>;
 
@@ -44,7 +44,7 @@ export const PanelComponent: ComponentConfig<PanelProps> = {
 const UiBlock = ({ id, components, title, collapsible, collapsed, visible }: UiComponentProps<PanelProps>) => (
   <div className={`i-panel ${collapsible && collapsed ? 'default-collapsed' : ''}`}>
     <div className='i-panel-header'>
-      {title}
+      <UiBadge value={title} />
       <Flex gap={1} alignItems='center'>
         <UiBlockHeaderVisiblePart visible={visible} />
         {collapsible ? (


### PR DESCRIPTION
I added the Badge component to Fieldset and Panel titles, similar to how it is already used in the Button component:
![grafik](https://github.com/user-attachments/assets/66321a63-dc1f-4015-902c-dc81af0758d6)
![grafik](https://github.com/user-attachments/assets/d72f7bb2-f000-4385-9338-b5d3464e107b)
