### PR TITLE
Improve browser options

### DIFF
--- a/packages/editor/src/components/blocks/base.tsx
+++ b/packages/editor/src/components/blocks/base.tsx
@@ -55,45 +55,44 @@ export const baseComponentFields: Fields<BaseComponentProps> = {
 };
 
 export const visibleComponentField: Fields<VisibleItemProps> = {
-  visible: { subsection: 'Behaviour', label: 'Visible', type: 'textBrowser', browsers: ['CONDITION'] }
+  visible: { subsection: 'Behaviour', label: 'Visible', type: 'textBrowser', browsers: [{ type: 'CONDITION' }] }
 };
 
 export const disabledComponentFields: Fields<DisabledItemProps> = {
   ...visibleComponentField,
-  disabled: { subsection: 'Behaviour', label: 'Disable', type: 'textBrowser', browsers: ['CONDITION'] }
+  disabled: { subsection: 'Behaviour', label: 'Disable', type: 'textBrowser', browsers: [{ type: 'CONDITION' }] }
 };
 
 export const behaviourComponentFields: Fields<BehaviourItemProps> = {
   ...disabledComponentFields,
-  required: { subsection: 'Behaviour', label: 'Required', type: 'textBrowser', browsers: ['CONDITION'] },
+  required: { subsection: 'Behaviour', label: 'Required', type: 'textBrowser', browsers: [{ type: 'CONDITION' }] },
   requiredMessage: {
     subsection: 'Behaviour',
     label: 'Required Message',
     type: 'textBrowser',
-    browsers: ['CMS'],
+    browsers: [{ type: 'CMS', options: { overrideSelection: true } }],
     hide: data => data.required.length === 0
   },
   updateOnChange: { subsection: 'Behaviour', label: 'Update Form on Change', type: 'checkbox' }
 };
 
 export const selectItemsComponentFields: Fields<SelectItemsProps> = {
-  label: { subsection: 'General', label: 'Label', type: 'textBrowser', browsers: ['CMS'] },
-  value: { subsection: 'General', label: 'Value', type: 'textBrowser', browsers: ['ATTRIBUTE'] },
+  label: { subsection: 'General', label: 'Label', type: 'textBrowser', browsers: [{ type: 'CMS', options: { overrideSelection: true } }] },
+  value: { subsection: 'General', label: 'Value', type: 'textBrowser', browsers: [{ type: 'ATTRIBUTE' }] },
   staticItems: { subsection: 'Static Options', label: 'Options', type: 'selectTable' },
   dynamicItemsList: {
     subsection: 'Dynamic Options',
     label: 'List of Objects',
     type: 'textBrowser',
-    browsers: ['ATTRIBUTE'],
-    options: { typeHint: 'List', placeholder: 'e.g. #{data.dynamicList}' }
+    browsers: [{ type: 'ATTRIBUTE', options: { typeHint: 'List' } }],
+    options: { placeholder: 'e.g. #{data.dynamicList}' }
   },
   dynamicItemsLabel: {
     subsection: 'Dynamic Options',
     label: 'Object Label',
     type: 'textBrowser',
-    browsers: ['ATTRIBUTE'],
+    browsers: [{ type: 'ATTRIBUTE', options: { onlyAttributes: 'DYNAMICLIST', withoutEl: true } }],
     options: {
-      onlyAttributes: 'DYNAMICLIST',
       placeholder: 'Enter attribute (or leave blank to select entire object)'
     },
     hide: data => data.dynamicItemsList.length == 0
@@ -102,9 +101,8 @@ export const selectItemsComponentFields: Fields<SelectItemsProps> = {
     subsection: 'Dynamic Options',
     label: 'Object Value',
     type: 'textBrowser',
-    browsers: ['ATTRIBUTE'],
+    browsers: [{ type: 'ATTRIBUTE', options: { onlyAttributes: 'DYNAMICLIST', withoutEl: true } }],
     options: {
-      onlyAttributes: 'DYNAMICLIST',
       placeholder: 'Enter attribute (or leave blank to select entire object)'
     },
     hide: data => data.dynamicItemsList.length == 0

--- a/packages/editor/src/components/blocks/button/Button.tsx
+++ b/packages/editor/src/components/blocks/button/Button.tsx
@@ -37,13 +37,12 @@ export const ButtonComponent: ComponentConfig<ButtonProps> = {
   outlineInfo: component => component.name,
   fields: {
     ...baseComponentFields,
-    name: { subsection: 'General', label: 'Name', type: 'textBrowser', browsers: ['CMS'] },
+    name: { subsection: 'General', label: 'Name', type: 'textBrowser', browsers: [{ type: 'CMS', options: { overrideSelection: true } }] },
     action: {
       subsection: 'General',
       label: 'Action',
       type: 'textBrowser',
-      browsers: ['LOGIC', 'ATTRIBUTE'],
-      options: { overrideSelection: true }
+      browsers: [{ type: 'LOGIC' }, { type: 'ATTRIBUTE', options: { withoutEl: true, overrideSelection: true } }]
     },
     variant: { subsection: 'General', label: 'Variant', type: 'select', options: variantOptions },
     type: { subsection: 'General', label: 'Type', type: 'hidden' },

--- a/packages/editor/src/components/blocks/checkbox/Checkbox.tsx
+++ b/packages/editor/src/components/blocks/checkbox/Checkbox.tsx
@@ -29,8 +29,13 @@ export const CheckboxComponent: ComponentConfig<CheckboxProps> = {
   outlineInfo: component => component.label,
   fields: {
     ...baseComponentFields,
-    label: { subsection: 'General', label: 'Label', type: 'textBrowser', browsers: ['CMS'] },
-    selected: { subsection: 'General', label: 'Selected', type: 'textBrowser', browsers: ['ATTRIBUTE'] },
+    label: {
+      subsection: 'General',
+      label: 'Label',
+      type: 'textBrowser',
+      browsers: [{ type: 'CMS', options: { overrideSelection: true } }]
+    },
+    selected: { subsection: 'General', label: 'Selected', type: 'textBrowser', browsers: [{ type: 'ATTRIBUTE' }] },
     ...disabledComponentFields,
     updateOnChange: { subsection: 'Behaviour', label: 'Update Form on Change', type: 'checkbox' }
   },

--- a/packages/editor/src/components/blocks/combobox/Combobox.tsx
+++ b/packages/editor/src/components/blocks/combobox/Combobox.tsx
@@ -32,9 +32,14 @@ export const ComboboxComponent: ComponentConfig<ComboboxProps> = {
   outlineInfo: component => component.label,
   fields: {
     ...baseComponentFields,
-    label: { subsection: 'General', label: 'Label', type: 'textBrowser', browsers: ['CMS'] },
-    value: { subsection: 'General', label: 'Value', type: 'textBrowser', browsers: ['ATTRIBUTE'] },
-    completeMethod: { subsection: 'Options', label: 'Complete Method', type: 'textBrowser', browsers: ['LOGIC'] },
+    label: {
+      subsection: 'General',
+      label: 'Label',
+      type: 'textBrowser',
+      browsers: [{ type: 'CMS', options: { overrideSelection: true } }]
+    },
+    value: { subsection: 'General', label: 'Value', type: 'textBrowser', browsers: [{ type: 'ATTRIBUTE' }] },
+    completeMethod: { subsection: 'Options', label: 'Complete Method', type: 'textBrowser', browsers: [{ type: 'LOGIC' }] },
     itemLabel: {
       subsection: 'Options',
       label: 'Item Label',

--- a/packages/editor/src/components/blocks/composite/fields/Parameters.tsx
+++ b/packages/editor/src/components/blocks/composite/fields/Parameters.tsx
@@ -56,9 +56,8 @@ const ParameterInput = ({ value, onChange, name, description, type, validationPa
       label={capitalize(name)}
       value={value[name]}
       onChange={change => updateValue(name, change)}
-      browsers={['ATTRIBUTE']}
+      browsers={[{ type: 'ATTRIBUTE', options: { typeHint: type } }]}
       message={message ?? { variant: 'description', message: description }}
-      options={{ typeHint: type }}
     />
   );
 };

--- a/packages/editor/src/components/blocks/datatable/DataTable.tsx
+++ b/packages/editor/src/components/blocks/datatable/DataTable.tsx
@@ -42,8 +42,7 @@ export const DataTableComponent: ComponentConfig<DataTableProps> = {
       subsection: 'General',
       label: 'List of Objects',
       type: 'textBrowser',
-      browsers: ['ATTRIBUTE'],
-      options: { typeHint: 'List' }
+      browsers: [{ type: 'ATTRIBUTE', options: { typeHint: 'List' } }]
     },
     components: { subsection: 'Columns', label: 'Object-Bound Columns', type: 'generic', render: () => <ColumnsField /> },
     paginator: { subsection: 'Paginator', label: 'Enable Paginator', type: 'checkbox' },

--- a/packages/editor/src/components/blocks/datatablecolumn/DataTableColumn.tsx
+++ b/packages/editor/src/components/blocks/datatablecolumn/DataTableColumn.tsx
@@ -37,7 +37,12 @@ export const DataTableColumnComponent: ComponentConfig<DataTableColumnProps> = {
   outlineInfo: component => component.header,
   fields: {
     ...baseComponentFields,
-    header: { subsection: 'General', label: 'Header', type: 'textBrowser', browsers: ['CMS'] },
+    header: {
+      subsection: 'General',
+      label: 'Header',
+      type: 'textBrowser',
+      browsers: [{ type: 'CMS', options: { overrideSelection: true } }]
+    },
     asActionColumn: { subsection: 'General', label: 'Action Column', type: 'checkbox' },
     actionColumnAsMenu: { subsection: 'Content', label: 'Group Actions', type: 'checkbox', hide: data => !data.asActionColumn },
     components: {
@@ -51,8 +56,7 @@ export const DataTableColumnComponent: ComponentConfig<DataTableColumnProps> = {
       subsection: 'Content',
       label: 'Value',
       type: 'textBrowser',
-      browsers: ['ATTRIBUTE'],
-      options: { onlyAttributes: 'COLUMN' },
+      browsers: [{ type: 'ATTRIBUTE', options: { onlyAttributes: 'COLUMN', withoutEl: true } }],
       hide: data => data.asActionColumn
     },
     sortable: { subsection: 'General', label: 'Enable Sorting', type: 'checkbox', hide: data => data.asActionColumn },

--- a/packages/editor/src/components/blocks/datepicker/DatePicker.tsx
+++ b/packages/editor/src/components/blocks/datepicker/DatePicker.tsx
@@ -29,8 +29,13 @@ export const DatePickerComponent: ComponentConfig<DatePickerProps> = {
   outlineInfo: component => component.label,
   fields: {
     ...baseComponentFields,
-    label: { subsection: 'General', label: 'Label', type: 'textBrowser', browsers: ['CMS'] },
-    value: { subsection: 'General', label: 'Value', type: 'textBrowser', browsers: ['ATTRIBUTE'], options: { typeHint: 'Date' } },
+    label: {
+      subsection: 'General',
+      label: 'Label',
+      type: 'textBrowser',
+      browsers: [{ type: 'CMS', options: { overrideSelection: true } }]
+    },
+    value: { subsection: 'General', label: 'Value', type: 'textBrowser', browsers: [{ type: 'ATTRIBUTE', options: { typeHint: 'Date' } }] },
     datePattern: { subsection: 'General', label: 'Date Pattern', type: 'text', options: { placeholder: 'e.g. dd.MM.yyyy' } },
     showTime: { subsection: 'General', label: 'Show Time', type: 'checkbox' },
     timePattern: {

--- a/packages/editor/src/components/blocks/fieldset/Fieldset.tsx
+++ b/packages/editor/src/components/blocks/fieldset/Fieldset.tsx
@@ -33,7 +33,15 @@ export const FieldsetComponent: ComponentConfig<FieldsetProps> = {
   fields: {
     ...baseComponentFields,
     components: { subsection: 'General', type: 'hidden' },
-    legend: { subsection: 'General', label: 'Title', type: 'textBrowser', browsers: ['ATTRIBUTE', 'CMS'] },
+    legend: {
+      subsection: 'General',
+      label: 'Title',
+      type: 'textBrowser',
+      browsers: [
+        { type: 'ATTRIBUTE', options: { overrideSelection: true } },
+        { type: 'CMS', options: { overrideSelection: true } }
+      ]
+    },
     collapsible: { subsection: 'Behaviour', label: 'Collapsible', type: 'checkbox' },
     collapsed: { subsection: 'Behaviour', label: 'Collapsed by default', type: 'checkbox', hide: data => !data.collapsible },
     ...visibleComponentField

--- a/packages/editor/src/components/blocks/input/Input.tsx
+++ b/packages/editor/src/components/blocks/input/Input.tsx
@@ -48,8 +48,13 @@ export const InputComponent: ComponentConfig<InputProps> = {
   outlineInfo: component => component.label,
   fields: {
     ...baseComponentFields,
-    label: { subsection: 'General', label: 'Label', type: 'textBrowser', browsers: ['CMS'] },
-    value: { subsection: 'General', label: 'Value', type: 'textBrowser', browsers: ['ATTRIBUTE'] },
+    label: {
+      subsection: 'General',
+      label: 'Label',
+      type: 'textBrowser',
+      browsers: [{ type: 'CMS', options: { overrideSelection: true } }]
+    },
+    value: { subsection: 'General', label: 'Value', type: 'textBrowser', browsers: [{ type: 'ATTRIBUTE' }] },
     type: { subsection: 'General', label: 'Type', type: 'select', options: typeOptions },
     decimalPlaces: { subsection: 'Formatting', label: 'Decimal Places', type: 'number', hide: data => data.type !== 'NUMBER' },
     symbol: { subsection: 'Formatting', label: 'Symbol', type: 'text', hide: data => data.type !== 'NUMBER' },

--- a/packages/editor/src/components/blocks/link/Link.tsx
+++ b/packages/editor/src/components/blocks/link/Link.tsx
@@ -26,7 +26,7 @@ export const LinkComponent: ComponentConfig<LinkProps> = {
   outlineInfo: component => component.name,
   fields: {
     ...baseComponentFields,
-    name: { subsection: 'General', label: 'Name', type: 'textBrowser', browsers: ['CMS'] },
+    name: { subsection: 'General', label: 'Name', type: 'textBrowser', browsers: [{ type: 'CMS', options: { overrideSelection: true } }] },
     href: { subsection: 'General', label: 'Href', type: 'text' },
     ...visibleComponentField
   },

--- a/packages/editor/src/components/blocks/panel/Panel.tsx
+++ b/packages/editor/src/components/blocks/panel/Panel.tsx
@@ -34,7 +34,15 @@ export const PanelComponent: ComponentConfig<PanelProps> = {
   fields: {
     ...baseComponentFields,
     components: { subsection: 'General', type: 'hidden' },
-    title: { subsection: 'General', label: 'Title', type: 'textBrowser', browsers: ['ATTRIBUTE', 'CMS'] },
+    title: {
+      subsection: 'General',
+      label: 'Title',
+      type: 'textBrowser',
+      browsers: [
+        { type: 'ATTRIBUTE', options: { overrideSelection: true } },
+        { type: 'CMS', options: { overrideSelection: true } }
+      ]
+    },
     collapsible: { subsection: 'Behaviour', label: 'Collapsible', type: 'checkbox' },
     collapsed: { subsection: 'Behaviour', label: 'Collapsed by default', type: 'checkbox', options: {}, hide: data => !data.collapsible },
     ...visibleComponentField

--- a/packages/editor/src/components/blocks/textarea/Textarea.tsx
+++ b/packages/editor/src/components/blocks/textarea/Textarea.tsx
@@ -28,8 +28,13 @@ export const TextareaComponent: ComponentConfig<TextareaProps> = {
   outlineInfo: component => component.label,
   fields: {
     ...baseComponentFields,
-    label: { subsection: 'General', label: 'Label', type: 'textBrowser', browsers: ['CMS'] },
-    value: { subsection: 'General', label: 'Value', type: 'textBrowser', browsers: ['ATTRIBUTE'] },
+    label: {
+      subsection: 'General',
+      label: 'Label',
+      type: 'textBrowser',
+      browsers: [{ type: 'CMS', options: { overrideSelection: true } }]
+    },
+    value: { subsection: 'General', label: 'Value', type: 'textBrowser', browsers: [{ type: 'ATTRIBUTE' }] },
     rows: { subsection: 'General', label: 'Visible Rows', type: 'number' },
     autoResize: { subsection: 'General', label: 'Auto Resize', type: 'checkbox' },
     ...behaviourComponentFields

--- a/packages/editor/src/editor/browser/browser.test.ts
+++ b/packages/editor/src/editor/browser/browser.test.ts
@@ -1,0 +1,35 @@
+import { expect } from 'vitest';
+import { getApplyLogicValue, type FormBrowser } from './Browser';
+import type { Selection } from './cms/useTextSelection';
+
+test('return null if result is undefined', () => {
+  expect(getApplyLogicValue('initial', undefined, 'ATTRIBUTE', [])).toBeNull();
+});
+
+test('return result value wrapped in #{ } if withoutEl is false or undefined', () => {
+  const result = { value: 'testValue' };
+  const activeBrowsers: FormBrowser[] = [{ type: 'ATTRIBUTE', options: {} }];
+  expect(getApplyLogicValue('initial', result, 'ATTRIBUTE', activeBrowsers)).toBe('#{testValue}');
+});
+
+test('return result value as is if withoutEl is true', () => {
+  const result = { value: 'testValue' };
+  const activeBrowsers: FormBrowser[] = [{ type: 'ATTRIBUTE', options: { withoutEl: true } }];
+  expect(getApplyLogicValue('initial', result, 'ATTRIBUTE', activeBrowsers)).toBe('testValue');
+});
+
+test('override selection when overrideSelection is true', () => {
+  const result = { value: 'newContent' };
+  const activeBrowsers: FormBrowser[] = [
+    { type: 'ATTRIBUTE', options: { overrideSelection: true } },
+    { type: 'CMS', options: { withoutEl: true } }
+  ];
+  const selection: Selection = { start: 3, end: 7 };
+  expect(getApplyLogicValue('abcdefg', result, 'ATTRIBUTE', activeBrowsers, selection)).toBe('abc#{newContent}');
+});
+
+test('append new value when overrideSelection is true but selection is undefined', () => {
+  const result = { value: 'newContent' };
+  const activeBrowsers: FormBrowser[] = [{ type: 'ATTRIBUTE', options: { overrideSelection: true } }];
+  expect(getApplyLogicValue('existing', result, 'ATTRIBUTE', activeBrowsers)).toBe('existing#{newContent}');
+});

--- a/packages/editor/src/editor/browser/cms/AddCmsQuickFix.tsx
+++ b/packages/editor/src/editor/browser/cms/AddCmsQuickFix.tsx
@@ -34,7 +34,7 @@ export const AddCmsQuickFixPopover = ({ value, onChange, selection, inputRef }: 
         queryClient.invalidateQueries({
           queryKey: genQueryKey('meta/cms/cmsQuickActions', { context, text: value })
         });
-        if (inputRef.current && selection) {
+        if (inputRef.current && selection && selection.start !== selection.end) {
           const currentValue = inputRef.current.value;
           const newValue = currentValue.slice(0, selection.start) + data + currentValue.slice(selection.end);
           inputRef.current.setSelectionRange(selection.start + data.length, selection.start + data.length);

--- a/packages/editor/src/editor/browser/cms/useTextSelection.test.ts
+++ b/packages/editor/src/editor/browser/cms/useTextSelection.test.ts
@@ -23,14 +23,6 @@ describe('handleTextSelection', () => {
     expect(result.current.selection).toEqual({ start: 2, end: 6 });
   });
 
-  test('set undefined if start and end are the same', () => {
-    const ref = mockRef('sample text', 3, 3);
-    const { result } = renderHook(() => useTextSelection(ref));
-    act(() => result.current.handleTextSelection());
-
-    expect(result.current.selection).toBeUndefined();
-  });
-
   test('do nothing if ref is null', () => {
     const ref = { current: null } as InputTextAreaRef;
     const { result } = renderHook(() => useTextSelection(ref));

--- a/packages/editor/src/editor/browser/cms/useTextSelection.ts
+++ b/packages/editor/src/editor/browser/cms/useTextSelection.ts
@@ -9,11 +9,7 @@ const useTextSelection = (ref: InputTextAreaRef) => {
     if (ref.current) {
       const selectionStart = ref.current.selectionStart ?? 0;
       const selectionEnd = ref.current.selectionEnd ?? 0;
-      if (selectionStart !== selectionEnd) {
-        setSelection({ start: selectionStart, end: selectionEnd });
-      } else {
-        setSelection(undefined);
-      }
+      setSelection({ start: selectionStart, end: selectionEnd });
     }
   };
 

--- a/packages/editor/src/editor/sidebar/fields/InputFieldWithBrowser.tsx
+++ b/packages/editor/src/editor/sidebar/fields/InputFieldWithBrowser.tsx
@@ -2,9 +2,9 @@ import { BasicField, BasicInput, Button, Dialog, DialogContent, DialogTrigger, I
 import { IvyIcons } from '@axonivy/ui-icons';
 import { useRef, useState } from 'react';
 import type { InputFieldProps } from './InputField';
-import type { TextBrowserFieldOptions } from '../../../types/config';
+import type { TextFieldOptions } from '../../../types/config';
 import { focusBracketContent } from '../../../utils/focus';
-import { Browser, type BrowserType } from '../../browser/Browser';
+import { Browser, type FormBrowser } from '../../browser/Browser';
 import { AddCmsQuickFixPopover } from '../../browser/cms/AddCmsQuickFix';
 import useTextSelection from '../../browser/cms/useTextSelection';
 import { badgeProps } from '../../../utils/badge-properties';
@@ -18,7 +18,7 @@ export const InputFieldWithBrowser = ({
   onBlur,
   message,
   options
-}: InputFieldProps & { browsers: Array<BrowserType>; options?: TextBrowserFieldOptions }) => {
+}: InputFieldProps & { browsers: Array<FormBrowser>; options?: TextFieldOptions }) => {
   const [open, setOpen] = useState(false);
 
   const inputRef = useRef<HTMLInputElement>(null);
@@ -37,8 +37,9 @@ export const InputFieldWithBrowser = ({
               onSelect={() => handleTextSelection()}
               onBlur={onBlur}
               placeholder={options?.placeholder}
+              disabled={options?.disabled}
             />
-            {showQuickFix() && browsers.some(b => b === 'CMS') && (
+            {showQuickFix() && browsers.some(b => b.type === 'CMS') && (
               <AddCmsQuickFixPopover
                 value={getSelectedText()}
                 selection={selection}
@@ -59,16 +60,9 @@ export const InputFieldWithBrowser = ({
       </BasicField>
       <DialogContent
         style={{ height: '80vh' }}
-        onCloseAutoFocus={browsers.includes('LOGIC') ? e => focusBracketContent(e, value, inputRef.current) : undefined}
+        onCloseAutoFocus={browsers.find(b => b.type === 'LOGIC') ? e => focusBracketContent(e, value, inputRef.current) : undefined}
       >
-        <Browser
-          activeBrowsers={browsers}
-          close={() => setOpen(false)}
-          value={value}
-          onChange={onChange}
-          options={options}
-          selection={selection}
-        />
+        <Browser activeBrowsers={browsers} close={() => setOpen(false)} value={value} onChange={onChange} selection={selection} />
       </DialogContent>
     </Dialog>
   );

--- a/packages/editor/src/editor/sidebar/fields/TextareaField.tsx
+++ b/packages/editor/src/editor/sidebar/fields/TextareaField.tsx
@@ -73,7 +73,16 @@ export const TextareaField = ({ label, value, onChange, message }: TextareaField
         )}
       </BasicField>
       <DialogContent style={{ height: '80vh' }}>
-        <Browser activeBrowsers={['CMS']} close={() => setOpen(false)} value={value} onChange={onChange} />
+        <Browser
+          activeBrowsers={[
+            { type: 'CMS', options: { overrideSelection: true } },
+            { type: 'ATTRIBUTE', options: { overrideSelection: true } }
+          ]}
+          close={() => setOpen(false)}
+          value={value}
+          onChange={onChange}
+          selection={selection}
+        />
       </DialogContent>
     </Dialog>
   );

--- a/packages/editor/src/editor/sidebar/fields/table-field/InputCellWithBrowser.tsx
+++ b/packages/editor/src/editor/sidebar/fields/table-field/InputCellWithBrowser.tsx
@@ -10,5 +10,13 @@ type InputCellProps<TData> = InputProps & {
 export const InputCellWithBrowser = <TData,>({ cell }: InputCellProps<TData>) => {
   const { value, setValue, onBlur } = useEditCell(cell);
 
-  return <InputFieldWithBrowser label='' onChange={setValue} value={value} onBlur={onBlur} browsers={['ATTRIBUTE', 'CMS']} />;
+  return (
+    <InputFieldWithBrowser
+      label=''
+      onChange={setValue}
+      value={value}
+      onBlur={onBlur}
+      browsers={[{ type: 'ATTRIBUTE' }, { type: 'CMS', options: { overrideSelection: true } }]}
+    />
+  );
 };

--- a/packages/editor/src/types/config.ts
+++ b/packages/editor/src/types/config.ts
@@ -1,7 +1,7 @@
 import type { ComponentType, ConfigData, PrimitiveValue } from '@axonivy/form-editor-protocol';
 import type React from 'react';
 import type { ReactNode } from 'react';
-import type { BrowserOptions, BrowserType } from '../editor/browser/Browser';
+import type { FormBrowser } from '../editor/browser/Browser';
 import type { CollapsibleControlProps, IvyIconProps } from '@axonivy/ui-components';
 
 export type UiComponentProps<Props extends DefaultComponentProps = DefaultComponentProps> = Props & { id: string };
@@ -38,8 +38,6 @@ export type TextFieldOptions = {
   disabled?: boolean;
 };
 
-export type TextBrowserFieldOptions = TextFieldOptions & BrowserOptions;
-
 export type TextField<ComponentProps extends DefaultComponentProps = DefaultComponentProps> = BaseField<ComponentProps> & {
   type: 'text' | 'number' | 'textarea' | 'checkbox';
   options?: TextFieldOptions;
@@ -47,8 +45,8 @@ export type TextField<ComponentProps extends DefaultComponentProps = DefaultComp
 
 export type TextBrowserField<ComponentProps extends DefaultComponentProps = DefaultComponentProps> = BaseField<ComponentProps> & {
   type: 'textBrowser';
-  browsers: Array<BrowserType>;
-  options?: TextBrowserFieldOptions;
+  browsers: Array<FormBrowser>;
+  options?: TextFieldOptions;
 };
 
 export type TableField<ComponentProps extends DefaultComponentProps = DefaultComponentProps> = BaseField<ComponentProps> & {


### PR DESCRIPTION
For the following story (https://1ivy.atlassian.net/browse/XIVY-16015), I wanted to add an attribute browser to the content input field. Since it's a textarea field, I thought it would make sense for the attribute (and CMS) browser to insert the attribute EL expression at the cursor position instead of replacing the entire value.

However, this required extending the apply function in the browser component with additional if conditions and special cases. That made me wonder: wouldn't it be better to define browser-apply options per browser rather than globally for each input field?

I tried this approach and refactored it so that options are now passed directly in the browser array. What do you think? Does this approach make sense, or is it overkill? Should I revert to the previous implementation and expand the apply function instead?

The main advantage of this new approach is that the apply function in the browser component only relies on the options without additional if conditions for specific browsers in combination with certain options.