### PR TITLE
XIVY-15035 Rename "variable" for attr-browser of ActionColumn to "row"

### DIFF
--- a/packages/editor/src/editor/browser/data-class/useAttributeBrowser.tsx
+++ b/packages/editor/src/editor/browser/data-class/useAttributeBrowser.tsx
@@ -29,7 +29,7 @@ export const useAttributeBrowser = (options?: BrowserOptions): Browser => {
         getParentColumnComponent(data.components, element.cid).component
       );
       setTree([
-        ...findAttributesOfType(variableInfo, parentTableComponent ? parentTableComponent.value : ''),
+        ...findAttributesOfType(variableInfo, parentTableComponent ? parentTableComponent.value : '', 10, 'row'),
         ...variableTreeData().of(variableInfo)
       ]);
     } else {

--- a/packages/editor/src/editor/browser/data-class/variable-tree-data.ts
+++ b/packages/editor/src/editor/browser/data-class/variable-tree-data.ts
@@ -74,7 +74,12 @@ export const rowToCreateData = (row: Row<BrowserNode>): CreateComponentData | un
   };
 };
 
-export function findAttributesOfType(data: VariableInfo, variableName: string, maxDepth: number = 10): Array<BrowserNode<Variable>> {
+export function findAttributesOfType(
+  data: VariableInfo,
+  variableName: string,
+  maxDepth: number = 10,
+  parentName: string = 'variable'
+): Array<BrowserNode<Variable>> {
   const nameToSearch = extractVariableName(variableName);
 
   for (const attributes of Object.values(data.types)) {
@@ -85,7 +90,7 @@ export function findAttributesOfType(data: VariableInfo, variableName: string, m
 
       return [
         {
-          value: 'variable',
+          value: parentName,
           info: `${extractedType}`,
           icon: IvyIcons.Attribute,
           data: { attribute: nameToSearch, description: '', simpleType: extractedType, type: extractedType },


### PR DESCRIPTION
With this we could also maybe improve the naming for select/radio to "selectItem" and "radioItem" or just "item" 🤔 

https://github.com/axonivy/core/pull/8055
![grafik](https://github.com/user-attachments/assets/d784a6a6-8d53-4e24-9b00-9de1c5bfe3fa)
