### PR TITLE
XIVY-16283 removes duplicate translation of layout section

### DIFF
--- a/packages/editor/src/components/blocks/base.tsx
+++ b/packages/editor/src/components/blocks/base.tsx
@@ -92,28 +92,28 @@ export const useBase = () => {
     return {
       id: { subsection: 'General', type: 'generic', label: t('label.id'), render: props => <IdInput {...props} /> },
       alignSelf: {
-        section: categoryTranslations['Layout'],
+        section: 'Layout',
         subsection: 'General',
         type: 'toggleGroup',
         label: t('label.verticalAlign'),
         options: alignItemsOptions
       },
       lgSpan: {
-        section: categoryTranslations['Layout'],
+        section: 'Layout',
         subsection: 'General',
         type: 'select',
         label: t('label.largeSpan'),
         options: spanOptions
       },
       mdSpan: {
-        section: categoryTranslations['Layout'],
+        section: 'Layout',
         subsection: 'General',
         type: 'select',
         label: t('label.mediumSpan'),
         options: spanOptions
       }
     };
-  }, [categoryTranslations, t]);
+  }, [t]);
 
   const visibleComponentField: Fields<VisibleItemProps> = useMemo(() => {
     return {


### PR DESCRIPTION
- removes duplicate translation which resulted in undefined behavior:

section gets already translated when it's displayed
https://github.com/axonivy/form-editor-client/blob/25d92ead0c2b423a406f57d51b8f24d37b08e423/packages/editor/src/editor/sidebar/Properties.tsx#L47-L56
